### PR TITLE
SDI-528 Added adjustment type to allow sentence and key-date adjustments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/data/SentenceAdjustmentMappingDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/data/SentenceAdjustmentMappingDto.kt
@@ -11,8 +11,11 @@ import java.time.LocalDateTime
 @Schema(description = "NOMIS to Sentencing mapping")
 data class SentenceAdjustmentMappingDto(
 
-  @Schema(description = "NOMIS Sentence Adjustment id", required = true)
-  val nomisSentenceAdjustmentId: Long,
+  @Schema(description = "NOMIS Adjustment id", required = true)
+  val nomisAdjustmentId: Long,
+
+  @Schema(description = "NOMIS Adjustment type", required = true, allowableValues = ["SENTENCE", "BOOKING"])
+  val nomisAdjustmentType: String,
 
   @Schema(description = "Sentence Adjustment id", required = true)
   val sentenceAdjustmentId: Long,
@@ -31,7 +34,8 @@ data class SentenceAdjustmentMappingDto(
 ) {
   constructor(mapping: SentenceAdjustmentMapping) : this(
     sentenceAdjustmentId = mapping.sentenceAdjustmentId,
-    nomisSentenceAdjustmentId = mapping.nomisSentenceAdjustmentId,
+    nomisAdjustmentId = mapping.nomisAdjustmentId,
+    nomisAdjustmentType = mapping.nomisAdjustmentType,
     label = mapping.label,
     mappingType = mapping.mappingType.name,
     whenCreated = mapping.whenCreated

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/jpa/SentenceAdjustmentMapping.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/jpa/SentenceAdjustmentMapping.kt
@@ -11,7 +11,9 @@ data class SentenceAdjustmentMapping(
   @Id
   val sentenceAdjustmentId: Long,
 
-  val nomisSentenceAdjustmentId: Long,
+  val nomisAdjustmentId: Long,
+
+  val nomisAdjustmentType: String,
 
   /**
    * ISO timestamp of batch job if a migration

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/jpa/repository/SentenceAdjustmentMappingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/jpa/repository/SentenceAdjustmentMappingRepository.kt
@@ -9,7 +9,10 @@ import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.jpa.SentencingMapp
 
 @Repository
 interface SentenceAdjustmentMappingRepository : CoroutineCrudRepository<SentenceAdjustmentMapping, Long> {
-  suspend fun findOneByNomisSentenceAdjustmentId(nomisSentenceAdjustmentId: Long): SentenceAdjustmentMapping?
+  suspend fun findOneByNomisAdjustmentIdAndNomisAdjustmentType(
+    nomisAdjustmentId: Long,
+    nomisAdjustmentType: String
+  ): SentenceAdjustmentMapping?
   suspend fun findFirstByMappingTypeOrderByWhenCreatedDesc(mappingType: SentencingMappingType): SentenceAdjustmentMapping?
   suspend fun countAllByLabelAndMappingType(label: String, mappingType: SentencingMappingType): Long
   fun findAllByLabelAndMappingTypeOrderByLabelDesc(label: String, mappingType: SentencingMappingType, pageable: Pageable): Flow<SentenceAdjustmentMapping>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/resource/SentencingMappingResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/resource/SentencingMappingResource.kt
@@ -38,7 +38,12 @@ class SentencingMappingResource(private val mappingService: SentencingMappingSer
     summary = "Creates a new sentence adjustment mapping",
     description = "Creates a mapping between nomis sentence adjustment ids and Sentencing service id. Requires ROLE_NOMIS_SENTENCING",
     requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
-      content = [Content(mediaType = "application/json", schema = Schema(implementation = SentenceAdjustmentMappingDto::class))]
+      content = [
+        Content(
+          mediaType = "application/json",
+          schema = Schema(implementation = SentenceAdjustmentMappingDto::class)
+        )
+      ]
     ),
     responses = [
       ApiResponse(responseCode = "201", description = "Sentence adjustment mapping entry created"),
@@ -58,7 +63,7 @@ class SentencingMappingResource(private val mappingService: SentencingMappingSer
     mappingService.createSentenceAdjustmentMapping(createMappingRequest)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_SENTENCING')")
-  @GetMapping("/mapping/sentence-adjustments/nomis-sentence-adjustment-id/{nomisSentenceAdjustmentId}")
+  @GetMapping("/mapping/sentence-adjustments/nomis-adjustment-id/{nomisAdjustmentId}/nomis-adjustment-type/{nomisAdjustmentType}")
   @ResponseStatus(HttpStatus.OK)
   @Operation(
     summary = "get mapping",
@@ -87,10 +92,19 @@ class SentencingMappingResource(private val mappingService: SentencingMappingSer
     ]
   )
   suspend fun getSentenceAdjustmentMappingGivenNomisId(
-    @Schema(description = "NOMIS Sentence Adjustment Id", example = "12345", required = true)
+    @Schema(description = "NOMIS Adjustment Id", example = "12345", required = true)
     @PathVariable
-    nomisSentenceAdjustmentId: Long,
-  ): SentenceAdjustmentMappingDto = mappingService.getSentenceAdjustmentMappingByNomisId(nomisSentenceAdjustmentId)
+    nomisAdjustmentId: Long,
+    @Schema(
+      description = "NOMIS Adjustment Type",
+      example = "SENTENCE",
+      required = true,
+      allowableValues = ["SENTENCE", "BOOKING"]
+    )
+    @PathVariable
+    nomisAdjustmentType: String,
+  ): SentenceAdjustmentMappingDto =
+    mappingService.getSentenceAdjustmentMappingByNomisId(nomisAdjustmentId, nomisAdjustmentType)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_SENTENCING')")
   @GetMapping("/mapping/sentence-adjustments/sentence-adjustment-id/{sentenceAdjustmentId}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/resource/SentencingMappingResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/resource/SentencingMappingResource.kt
@@ -32,7 +32,7 @@ import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.service.Sentencing
 class SentencingMappingResource(private val mappingService: SentencingMappingService) {
 
   @PreAuthorize("hasRole('ROLE_NOMIS_SENTENCING')")
-  @PostMapping("/mapping/sentence-adjustments")
+  @PostMapping("/mapping/sentencing/adjustments")
   @ResponseStatus(HttpStatus.CREATED)
   @Operation(
     summary = "Creates a new sentence adjustment mapping",
@@ -63,7 +63,7 @@ class SentencingMappingResource(private val mappingService: SentencingMappingSer
     mappingService.createSentenceAdjustmentMapping(createMappingRequest)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_SENTENCING')")
-  @GetMapping("/mapping/sentence-adjustments/nomis-adjustment-id/{nomisAdjustmentId}/nomis-adjustment-type/{nomisAdjustmentType}")
+  @GetMapping("/mapping/sentencing/adjustments/nomis-adjustment-type/{nomisAdjustmentType}/nomis-adjustment-id/{nomisAdjustmentId}")
   @ResponseStatus(HttpStatus.OK)
   @Operation(
     summary = "get mapping",
@@ -107,7 +107,7 @@ class SentencingMappingResource(private val mappingService: SentencingMappingSer
     mappingService.getSentenceAdjustmentMappingByNomisId(nomisAdjustmentId, nomisAdjustmentType)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_SENTENCING')")
-  @GetMapping("/mapping/sentence-adjustments/sentence-adjustment-id/{sentenceAdjustmentId}")
+  @GetMapping("/mapping/sentencing/adjustments/sentence-adjustment-id/{sentenceAdjustmentId}")
   @ResponseStatus(HttpStatus.OK)
   @Operation(
     summary = "get mapping",
@@ -141,7 +141,7 @@ class SentencingMappingResource(private val mappingService: SentencingMappingSer
   ): SentenceAdjustmentMappingDto = mappingService.getSentenceAdjustmentMappingBySentencingId(sentenceAdjustmentId)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_SENTENCING')")
-  @GetMapping("/mapping/sentence-adjustments/migrated/latest")
+  @GetMapping("/mapping/sentencing/adjustments/migrated/latest")
   @ResponseStatus(HttpStatus.OK)
   @Operation(
     summary = "get the latest mapping for a migration",
@@ -173,7 +173,7 @@ class SentencingMappingResource(private val mappingService: SentencingMappingSer
     mappingService.getSentenceAdjustmentMappingForLatestMigrated()
 
   @PreAuthorize("hasRole('ROLE_NOMIS_SENTENCING')")
-  @DeleteMapping("/mapping/sentence-adjustments")
+  @DeleteMapping("/mapping/sentencing/adjustments")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @Operation(
     summary = "Deletes sentence adjustment mappings",
@@ -201,7 +201,7 @@ class SentencingMappingResource(private val mappingService: SentencingMappingSer
   )
 
   @PreAuthorize("hasRole('ROLE_NOMIS_SENTENCING')")
-  @DeleteMapping("/mapping/sentence-adjustments/sentence-adjustment-id/{sentenceAdjustmentId}")
+  @DeleteMapping("/mapping/sentencing/adjustments/sentence-adjustment-id/{sentenceAdjustmentId}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @Operation(
     summary = "Deletes a specific Sentence Adjustment mapping by sentence adjustment Id",
@@ -224,7 +224,7 @@ class SentencingMappingResource(private val mappingService: SentencingMappingSer
   ) = mappingService.deleteSentenceAdjustmentMapping(sentenceAdjustmentId)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_SENTENCING')")
-  @GetMapping("/mapping/sentence-adjustments/migration-id/{migrationId}")
+  @GetMapping("/mapping/sentencing/adjustments/migration-id/{migrationId}")
   @ResponseStatus(HttpStatus.OK)
   @Operation(
     summary = "get paged mappings by migration id",

--- a/src/main/resources/db/migration/V1_14__sentence_adjustment.sql
+++ b/src/main/resources/db/migration/V1_14__sentence_adjustment.sql
@@ -1,3 +1,4 @@
+truncate table sentence_adjustment_mapping;
 alter table sentence_adjustment_mapping drop column nomis_sentence_adjustment_id;
 
 alter table sentence_adjustment_mapping add column nomis_adjustment_id     bigint       not null;

--- a/src/main/resources/db/migration/V1_14__sentence_adjustment.sql
+++ b/src/main/resources/db/migration/V1_14__sentence_adjustment.sql
@@ -1,0 +1,7 @@
+alter table sentence_adjustment_mapping drop column nomis_sentence_adjustment_id;
+
+alter table sentence_adjustment_mapping add column nomis_adjustment_id     bigint       not null;
+alter table sentence_adjustment_mapping add column nomis_adjustment_type   varchar(20)       not null;
+
+create unique index  nomis_id
+    ON sentence_adjustment_mapping (nomis_adjustment_id, nomis_adjustment_type);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/jpa/repository/SentenceAdjustmentMappingRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/jpa/repository/SentenceAdjustmentMappingRepositoryTest.kt
@@ -26,7 +26,8 @@ class SentenceAdjustmentMappingRepositoryTest : TestBase() {
     repository.save(
       SentenceAdjustmentMapping(
         sentenceAdjustmentId = 123,
-        nomisSentenceAdjustmentId = 456,
+        nomisAdjustmentId = 456,
+        nomisAdjustmentType = "SENTENCE",
         label = "TIMESTAMP",
         mappingType = MIGRATED
       )
@@ -35,15 +36,17 @@ class SentenceAdjustmentMappingRepositoryTest : TestBase() {
     val persistedSentenceAdjustmentMappingBySentenceAdjustmentId = repository.findById(123L) ?: throw RuntimeException("123L not found")
     with(persistedSentenceAdjustmentMappingBySentenceAdjustmentId) {
       assertThat(sentenceAdjustmentId).isEqualTo(123L)
-      assertThat(nomisSentenceAdjustmentId).isEqualTo(456L)
+      assertThat(nomisAdjustmentId).isEqualTo(456L)
+      assertThat(nomisAdjustmentType).isEqualTo("SENTENCE")
       assertThat(label).isEqualTo("TIMESTAMP")
       assertThat(mappingType).isEqualTo(MIGRATED)
     }
 
-    val persistedSentenceAdjustmentMappingByNomisId = repository.findOneByNomisSentenceAdjustmentId(456L) ?: throw RuntimeException("456L not found")
+    val persistedSentenceAdjustmentMappingByNomisId = repository.findOneByNomisAdjustmentIdAndNomisAdjustmentType(456L, "SENTENCE") ?: throw RuntimeException("456L not found")
     with(persistedSentenceAdjustmentMappingByNomisId) {
       assertThat(sentenceAdjustmentId).isEqualTo(123L)
-      assertThat(nomisSentenceAdjustmentId).isEqualTo(456L)
+      assertThat(nomisAdjustmentId).isEqualTo(456L)
+      assertThat(nomisAdjustmentType).isEqualTo("SENTENCE")
       assertThat(label).isEqualTo("TIMESTAMP")
       assertThat(mappingType).isEqualTo(MIGRATED)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/resource/SentenceAdjustmentMappingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/resource/SentenceAdjustmentMappingResourceIntTest.kt
@@ -26,23 +26,27 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
   @Autowired
   lateinit var repository: SentenceAdjustmentMappingRepository
 
-  private val nomisSentenceAdjustId = 1234L
+  private val nomisAdjustId = 1234L
+  private val nomisAdjustType = "SENTENCE"
   private val sentenceAdjustId = 4444L
 
   private fun createSentenceAdjustmentMapping(
-    nomisSentenceAdjustmentId: Long = nomisSentenceAdjustId,
+    nomisAdjustmentId: Long = nomisAdjustId,
+    nomisAdjustmentType: String = nomisAdjustType,
     sentenceAdjustmentId: Long = sentenceAdjustId,
     label: String = "2022-01-01",
     mappingType: String = NOMIS_CREATED.name
   ): SentenceAdjustmentMappingDto = SentenceAdjustmentMappingDto(
-    nomisSentenceAdjustmentId = nomisSentenceAdjustmentId,
+    nomisAdjustmentId = nomisAdjustmentId,
+    nomisAdjustmentType = nomisAdjustmentType,
     sentenceAdjustmentId = sentenceAdjustmentId,
     label = label,
     mappingType = mappingType
   )
 
   private fun postCreateSentenceAdjustmentMappingRequest(
-    nomisSentenceAdjustmentId: Long = 1234L,
+    nomisAdjustmentId: Long = 1234L,
+    nomisAdjustmentType: String = "SENTENCE",
     sentenceAdjustmentId: Long = 4444L,
     label: String = "2022-01-01",
     mappingType: String = NOMIS_CREATED.name
@@ -53,7 +57,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
       .body(
         BodyInserters.fromValue(
           createSentenceAdjustmentMapping(
-            nomisSentenceAdjustmentId = nomisSentenceAdjustmentId,
+            nomisAdjustmentId = nomisAdjustmentId,
+            nomisAdjustmentType = nomisAdjustmentType,
             sentenceAdjustmentId = sentenceAdjustmentId,
             label = label,
             mappingType = mappingType
@@ -107,12 +112,12 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         webTestClient.post().uri("/mapping/sentence-adjustments")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
           .contentType(MediaType.APPLICATION_JSON)
-          .body(BodyInserters.fromValue(createSentenceAdjustmentMapping().copy(nomisSentenceAdjustmentId = 21)))
+          .body(BodyInserters.fromValue(createSentenceAdjustmentMapping().copy(nomisAdjustmentId = 21)))
           .exchange()
           .expectStatus().isBadRequest
           .expectBody(ErrorResponse::class.java)
           .returnResult().responseBody?.userMessage
-      ).isEqualTo("Validation failure: Sentence adjustment mapping nomisSentenceAdjustmentId = 1234 and sentenceAdjustmentId = 4444 already exists")
+      ).isEqualTo("Validation failure: Sentence adjustment mapping nomisAdjustmentId = 1234 with nomisAdjustmentType = SENTENCE and sentenceAdjustmentId = 4444 already exists")
     }
 
     @Test
@@ -123,10 +128,11 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .body(
           BodyInserters.fromValue(
             """{
-            "nomisSentenceAdjustmentId"     : $nomisSentenceAdjustId,
+            "nomisAdjustmentId"         : $nomisAdjustId,
+            "nomisAdjustmentType"       : "$nomisAdjustType",
             "sentenceAdjustmentId"      : $sentenceAdjustId,
-            "label"       : "2022-01-01",
-            "mappingType" : "SENTENCING_CREATED"
+            "label"                     : "2022-01-01",
+            "mappingType"               : "SENTENCING_CREATED"
           }"""
           )
         )
@@ -139,10 +145,11 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .body(
           BodyInserters.fromValue(
             """{
-            "nomisSentenceAdjustmentId"     : $nomisSentenceAdjustId,
+            "nomisAdjustmentId"         : $nomisAdjustId,
+            "nomisAdjustmentType"       : "$nomisAdjustType",
             "sentenceAdjustmentId"      : $sentenceAdjustId,
-            "label"       : "2022-01-01",
-            "mappingType" : "SENTENCING_CREATED"
+            "label"                     : "2022-01-01",
+            "mappingType"               : "SENTENCING_CREATED"
           }"""
           )
         )
@@ -163,7 +170,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
           .expectStatus().isBadRequest
           .expectBody(ErrorResponse::class.java)
           .returnResult().responseBody?.userMessage
-      ).isEqualTo("Validation failure: Sentence adjustment mapping nomisSentenceAdjustmentId = 1234 and sentenceAdjustmentId = 4444 already exists")
+      ).isEqualTo("Validation failure: Sentence adjustment mapping nomisAdjustmentId = 1234 with nomisAdjustmentType = SENTENCE and sentenceAdjustmentId = 4444 already exists")
     }
 
     @Test
@@ -174,7 +181,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .body(
           BodyInserters.fromValue(
             """{
-            "nomisSentenceAdjustmentId"     : $nomisSentenceAdjustId,
+            "nomisAdjustmentId"         : $nomisAdjustId,
+            "nomisAdjustmentType"       : "$nomisAdjustType",
             "sentenceAdjustmentId"      : $sentenceAdjustId,
             "label"       : "2022-01-01",
             "mappingType" : "SENTENCING_CREATED"
@@ -185,14 +193,15 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .expectStatus().isCreated
 
       val mapping1 =
-        webTestClient.get().uri("/mapping/sentence-adjustments/nomis-sentence-adjustment-id/$nomisSentenceAdjustId")
+        webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
           .exchange()
           .expectStatus().isOk
           .expectBody(SentenceAdjustmentMappingDto::class.java)
           .returnResult().responseBody!!
 
-      assertThat(mapping1.nomisSentenceAdjustmentId).isEqualTo(nomisSentenceAdjustId)
+      assertThat(mapping1.nomisAdjustmentId).isEqualTo(nomisAdjustId)
+      assertThat(mapping1.nomisAdjustmentType).isEqualTo(nomisAdjustType)
       assertThat(mapping1.sentenceAdjustmentId).isEqualTo(sentenceAdjustId)
       assertThat(mapping1.label).isEqualTo("2022-01-01")
       assertThat(mapping1.mappingType).isEqualTo("SENTENCING_CREATED")
@@ -204,7 +213,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .expectBody(SentenceAdjustmentMappingDto::class.java)
         .returnResult().responseBody!!
 
-      assertThat(mapping2.nomisSentenceAdjustmentId).isEqualTo(nomisSentenceAdjustId)
+      assertThat(mapping2.nomisAdjustmentId).isEqualTo(nomisAdjustId)
+      assertThat(mapping2.nomisAdjustmentType).isEqualTo(nomisAdjustType)
       assertThat(mapping2.sentenceAdjustmentId).isEqualTo(sentenceAdjustId)
       assertThat(mapping2.label).isEqualTo("2022-01-01")
       assertThat(mapping2.mappingType).isEqualTo("SENTENCING_CREATED")
@@ -219,7 +229,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
           .body(
             BodyInserters.fromValue(
               """{
-            "nomisSentenceAdjustmentId"     : $nomisSentenceAdjustId,
+            "nomisAdjustmentId"         : $nomisAdjustId,
+            "nomisAdjustmentType"       : "$nomisAdjustType",
             "label"       : "2022-01-01",
             "sentenceAdjustmentId" : $sentenceAdjustId
           }"""
@@ -241,7 +252,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
           .body(
             BodyInserters.fromValue(
               """{
-            "nomisSentenceAdjustmentId"     : $nomisSentenceAdjustId,
+            "nomisAdjustmentId"         : $nomisAdjustId,
+            "nomisAdjustmentType"       : "$nomisAdjustType",
             "label"       : "2022-01-01",
             "sentenceAdjustmentId" : $sentenceAdjustId,
             "mappingType" : "MASSIVELY_LONG_PROPERTY_SENTENCING_CREATED"
@@ -264,7 +276,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
           .body(
             BodyInserters.fromValue(
               """{
-            "nomisSentenceAdjustmentId"     : $nomisSentenceAdjustId,
+            "nomisAdjustmentId"         : $nomisAdjustId,
+            "nomisAdjustmentType"       : "$nomisAdjustType",
             "label"       : "2022-01-01",
             "mappingType" : "SENTENCING_CREATED"
           }"""
@@ -274,11 +287,11 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
           .expectStatus().isBadRequest
           .expectBody(ErrorResponse::class.java)
           .returnResult().responseBody?.userMessage
-      ).isEqualTo("Validation failure: JSON decoding error: Missing required creator property 'sentenceAdjustmentId' (index 1)")
+      ).isEqualTo("Validation failure: JSON decoding error: Missing required creator property 'sentenceAdjustmentId' (index 2)")
     }
   }
 
-  @DisplayName("GET /mapping/sentence-adjustments/nomis-sentence-adjustment-id/nomisSentenceAdjustId}")
+  @DisplayName("GET /mapping/sentence-adjustments/nomis-adjustment-id/{nomisAdjustId}/nomis-adjustment-type/{nomisAdjustType}")
   @Nested
   inner class GetNomisMappingTest {
 
@@ -289,14 +302,14 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden when no authority`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-sentence-adjustment-id/$nomisSentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
         .exchange()
         .expectStatus().isUnauthorized
     }
 
     @Test
     fun `access forbidden when no role`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-sentence-adjustment-id/$nomisSentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
         .headers(setAuthorisation(roles = listOf()))
         .exchange()
         .expectStatus().isForbidden
@@ -304,7 +317,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden with wrong role`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-sentence-adjustment-id/$nomisSentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
         .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
         .exchange()
         .expectStatus().isForbidden
@@ -321,14 +334,15 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .expectStatus().isCreated
 
       val mapping =
-        webTestClient.get().uri("/mapping/sentence-adjustments/nomis-sentence-adjustment-id/$nomisSentenceAdjustId")
+        webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
           .exchange()
           .expectStatus().isOk
           .expectBody(SentenceAdjustmentMappingDto::class.java)
           .returnResult().responseBody!!
 
-      assertThat(mapping.nomisSentenceAdjustmentId).isEqualTo(nomisSentenceAdjustId)
+      assertThat(mapping.nomisAdjustmentId).isEqualTo(nomisAdjustId)
+      assertThat(mapping.nomisAdjustmentType).isEqualTo(nomisAdjustType)
       assertThat(mapping.sentenceAdjustmentId).isEqualTo(sentenceAdjustId)
       assertThat(mapping.label).isEqualTo("2022-01-01")
       assertThat(mapping.mappingType).isEqualTo(NOMIS_CREATED.name)
@@ -356,7 +370,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isCreated
 
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-sentence-adjustment-id/$nomisSentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
@@ -404,7 +418,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .body(
           BodyInserters.fromValue(
             createSentenceAdjustmentMapping(
-              nomisSentenceAdjustmentId = 10,
+              nomisAdjustmentId = 10,
+              nomisAdjustmentType = "SENTENCE",
               sentenceAdjustmentId = 10,
               label = "2022-01-01T00:00:00",
               mappingType = "MIGRATED"
@@ -420,7 +435,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .body(
           BodyInserters.fromValue(
             createSentenceAdjustmentMapping(
-              nomisSentenceAdjustmentId = 20,
+              nomisAdjustmentId = 20,
+              nomisAdjustmentType = "SENTENCE",
               sentenceAdjustmentId = 20,
               label = "2022-01-02T00:00:00",
               mappingType = "MIGRATED"
@@ -436,7 +452,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .body(
           BodyInserters.fromValue(
             createSentenceAdjustmentMapping(
-              nomisSentenceAdjustmentId = 1,
+              nomisAdjustmentId = 1,
+              nomisAdjustmentType = "SENTENCE",
               sentenceAdjustmentId = 1,
               label = "2022-01-02T10:00:00",
               mappingType = MIGRATED.name
@@ -452,7 +469,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .body(
           BodyInserters.fromValue(
             createSentenceAdjustmentMapping(
-              nomisSentenceAdjustmentId = 99,
+              nomisAdjustmentId = 99,
+              nomisAdjustmentType = "SENTENCE",
               sentenceAdjustmentId = 199,
               label = "whatever",
               mappingType = SENTENCING_CREATED.name
@@ -469,7 +487,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .expectBody(SentenceAdjustmentMappingDto::class.java)
         .returnResult().responseBody!!
 
-      assertThat(mapping.nomisSentenceAdjustmentId).isEqualTo(1)
+      assertThat(mapping.nomisAdjustmentId).isEqualTo(1)
+      assertThat(mapping.nomisAdjustmentType).isEqualTo("SENTENCE")
       assertThat(mapping.sentenceAdjustmentId).isEqualTo(1)
       assertThat(mapping.label).isEqualTo("2022-01-02T10:00:00")
       assertThat(mapping.mappingType).isEqualTo("MIGRATED")
@@ -485,7 +504,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .body(
           BodyInserters.fromValue(
             createSentenceAdjustmentMapping(
-              nomisSentenceAdjustmentId = 77,
+              nomisAdjustmentId = 77,
+              nomisAdjustmentType = "SENTENCE",
               sentenceAdjustmentId = 77,
               label = "whatever",
               mappingType = SENTENCING_CREATED.name
@@ -506,7 +526,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     }
   }
 
-  @DisplayName("GET /mapping/sentence-adjustments/incentive/{sentenceAdjustId}")
+  @DisplayName("GET /mapping/sentence-adjustments/sentence-adjustment-id/{sentenceAdjustId}")
   @Nested
   inner class GetSentenceAdjustmentMappingTest {
 
@@ -555,7 +575,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .expectBody(SentenceAdjustmentMappingDto::class.java)
         .returnResult().responseBody!!
 
-      assertThat(mapping.nomisSentenceAdjustmentId).isEqualTo(nomisSentenceAdjustId)
+      assertThat(mapping.nomisAdjustmentId).isEqualTo(nomisAdjustId)
+      assertThat(mapping.nomisAdjustmentType).isEqualTo(nomisAdjustType)
       assertThat(mapping.sentenceAdjustmentId).isEqualTo(sentenceAdjustId)
       assertThat(mapping.label).isEqualTo("2022-01-01")
       assertThat(mapping.mappingType).isEqualTo(NOMIS_CREATED.name)
@@ -626,7 +647,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isCreated
 
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-sentence-adjustment-id/$nomisSentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
@@ -636,7 +657,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isNoContent
 
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-sentence-adjustment-id/$nomisSentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNotFound
@@ -657,7 +678,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .body(
           BodyInserters.fromValue(
             createSentenceAdjustmentMapping(
-              nomisSentenceAdjustmentId = 333,
+              nomisAdjustmentId = 333,
+              nomisAdjustmentType = "SENTENCE",
               sentenceAdjustmentId = 222,
               mappingType = MIGRATED.name
             )
@@ -671,12 +693,12 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isNoContent
 
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-sentence-adjustment-id/$nomisSentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
 
-      webTestClient.get().uri("/mapping/sentence-adjustments/sentence-adjustment-id/222")
+      webTestClient.get().uri("/mapping/sentence-adjustments/sentence-adjustment-id/222/nomis-adjustment-type/$nomisAdjustType")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNotFound
@@ -726,7 +748,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isOk
       // it is also present after creation by nomis id
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-sentence-adjustment-id/$nomisSentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
@@ -743,7 +765,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isNotFound
       // and also no longer present by nomis id
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-sentence-adjustment-id/$nomisSentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNotFound
@@ -809,7 +831,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
       (1L..4L).forEach {
         postCreateSentenceAdjustmentMappingRequest(
-          nomisSentenceAdjustmentId = it,
+          nomisAdjustmentId = it,
+          nomisAdjustmentType = "SENTENCE",
           sentenceAdjustmentId = it,
           label = "2022-01-01",
           mappingType = "MIGRATED"
@@ -817,14 +840,16 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
       }
       (5L..9L).forEach {
         postCreateSentenceAdjustmentMappingRequest(
-          nomisSentenceAdjustmentId = it,
+          nomisAdjustmentId = it,
+          nomisAdjustmentType = "SENTENCE",
           sentenceAdjustmentId = it,
           label = "2099-01-01",
           mappingType = "MIGRATED"
         )
       }
       postCreateSentenceAdjustmentMappingRequest(
-        nomisSentenceAdjustmentId = 12,
+        nomisAdjustmentId = 12,
+        nomisAdjustmentType = "SENTENCE",
         sentenceAdjustmentId = 12, mappingType = SENTENCING_CREATED.name
       )
 
@@ -834,7 +859,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .expectStatus().isOk
         .expectBody()
         .jsonPath("totalElements").isEqualTo(4)
-        .jsonPath("$.content..nomisSentenceAdjustmentId").value(
+        .jsonPath("$.content..nomisAdjustmentId").value(
           Matchers.contains(
             1, 2, 3, 4
           )
@@ -847,7 +872,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
       (1L..4L).forEach {
         postCreateSentenceAdjustmentMappingRequest(
-          nomisSentenceAdjustmentId = it,
+          nomisAdjustmentId = it,
+          nomisAdjustmentType = "SENTENCE",
           sentenceAdjustmentId = it,
           label = "2022-01-01",
           mappingType = "MIGRATED"
@@ -868,7 +894,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
       (1L..6L).forEach {
         postCreateSentenceAdjustmentMappingRequest(
-          nomisSentenceAdjustmentId = it,
+          nomisAdjustmentId = it,
+          nomisAdjustmentType = "SENTENCE",
           sentenceAdjustmentId = it,
           label = "2022-01-01",
           mappingType = "MIGRATED"
@@ -877,7 +904,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
       webTestClient.get().uri {
         it.path("/mapping/sentence-adjustments/migration-id/2022-01-01")
           .queryParam("size", "2")
-          .queryParam("sort", "nomisSentenceAdjustmentId,asc")
+          .queryParam("sort", "nomisAdjustmentId,asc")
           .build()
       }
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
@@ -895,7 +922,8 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     fun `can request a different page`() {
       (1L..3L).forEach {
         postCreateSentenceAdjustmentMappingRequest(
-          nomisSentenceAdjustmentId = it,
+          nomisAdjustmentId = it,
+          nomisAdjustmentType = "SENTENCE",
           sentenceAdjustmentId = it,
           label = "2022-01-01",
           mappingType = "MIGRATED"
@@ -905,7 +933,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         it.path("/mapping/sentence-adjustments/migration-id/2022-01-01")
           .queryParam("size", "2")
           .queryParam("page", "1")
-          .queryParam("sort", "nomisSentenceAdjustmentId,asc")
+          .queryParam("sort", "nomisAdjustmentId,asc")
           .build()
       }
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/resource/SentenceAdjustmentMappingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/resource/SentenceAdjustmentMappingResourceIntTest.kt
@@ -51,7 +51,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     label: String = "2022-01-01",
     mappingType: String = NOMIS_CREATED.name
   ) {
-    webTestClient.post().uri("/mapping/sentence-adjustments")
+    webTestClient.post().uri("/mapping/sentencing/adjustments")
       .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
       .contentType(MediaType.APPLICATION_JSON)
       .body(
@@ -69,7 +69,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
       .expectStatus().isCreated
   }
 
-  @DisplayName("POST /mapping/sentence-adjustments")
+  @DisplayName("POST /mapping/sentencing/adjustments")
   @Nested
   inner class CreateSentenceAdjustmentMappingTest {
 
@@ -80,7 +80,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden when no authority`() {
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .body(BodyInserters.fromValue(createSentenceAdjustmentMapping()))
         .exchange()
         .expectStatus().isUnauthorized
@@ -88,7 +88,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden when no role`() {
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf()))
         .body(BodyInserters.fromValue(createSentenceAdjustmentMapping()))
         .exchange()
@@ -97,7 +97,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `create forbidden with wrong role`() {
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
         .body(BodyInserters.fromValue(createSentenceAdjustmentMapping()))
         .exchange()
@@ -109,7 +109,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
       postCreateSentenceAdjustmentMappingRequest()
 
       assertThat(
-        webTestClient.post().uri("/mapping/sentence-adjustments")
+        webTestClient.post().uri("/mapping/sentencing/adjustments")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
           .contentType(MediaType.APPLICATION_JSON)
           .body(BodyInserters.fromValue(createSentenceAdjustmentMapping().copy(nomisAdjustmentId = 21)))
@@ -122,7 +122,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     internal fun `create mapping does not error when the same mapping already exists for the same adjustment`() {
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(
@@ -139,7 +139,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isCreated
 
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(
@@ -162,7 +162,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
       postCreateSentenceAdjustmentMappingRequest()
 
       assertThat(
-        webTestClient.post().uri("/mapping/sentence-adjustments")
+        webTestClient.post().uri("/mapping/sentencing/adjustments")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
           .contentType(MediaType.APPLICATION_JSON)
           .body(BodyInserters.fromValue(createSentenceAdjustmentMapping().copy(sentenceAdjustmentId = 99)))
@@ -175,7 +175,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `create mapping success`() {
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(
@@ -193,7 +193,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .expectStatus().isCreated
 
       val mapping1 =
-        webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
+        webTestClient.get().uri("/mapping/sentencing/adjustments/nomis-adjustment-type/$nomisAdjustType/nomis-adjustment-id/$nomisAdjustId")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
           .exchange()
           .expectStatus().isOk
@@ -206,7 +206,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
       assertThat(mapping1.label).isEqualTo("2022-01-01")
       assertThat(mapping1.mappingType).isEqualTo("SENTENCING_CREATED")
 
-      val mapping2 = webTestClient.get().uri("/mapping/sentence-adjustments/sentence-adjustment-id/$sentenceAdjustId")
+      val mapping2 = webTestClient.get().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/$sentenceAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
@@ -223,7 +223,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     @Test
     fun `create rejects bad filter data - missing mapping type`() {
       assertThat(
-        webTestClient.post().uri("/mapping/sentence-adjustments")
+        webTestClient.post().uri("/mapping/sentencing/adjustments")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
           .contentType(MediaType.APPLICATION_JSON)
           .body(
@@ -246,7 +246,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     @Test
     fun `create rejects bad filter data - mapping max 20`() {
       assertThat(
-        webTestClient.post().uri("/mapping/sentence-adjustments")
+        webTestClient.post().uri("/mapping/sentencing/adjustments")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
           .contentType(MediaType.APPLICATION_JSON)
           .body(
@@ -270,7 +270,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     @Test
     fun `create rejects bad filter data - sentence adjustment property must be present (Long)`() {
       assertThat(
-        webTestClient.post().uri("/mapping/sentence-adjustments")
+        webTestClient.post().uri("/mapping/sentencing/adjustments")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
           .contentType(MediaType.APPLICATION_JSON)
           .body(
@@ -291,7 +291,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     }
   }
 
-  @DisplayName("GET /mapping/sentence-adjustments/nomis-adjustment-id/{nomisAdjustId}/nomis-adjustment-type/{nomisAdjustType}")
+  @DisplayName("GET /mapping/sentencing/adjustments/nomis-adjustment-id/{nomisAdjustId}/nomis-adjustment-type/{nomisAdjustType}")
   @Nested
   inner class GetNomisMappingTest {
 
@@ -302,14 +302,14 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden when no authority`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/nomis-adjustment-type/$nomisAdjustType/nomis-adjustment-id/$nomisAdjustId")
         .exchange()
         .expectStatus().isUnauthorized
     }
 
     @Test
     fun `access forbidden when no role`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/nomis-adjustment-type/$nomisAdjustType/nomis-adjustment-id/$nomisAdjustId")
         .headers(setAuthorisation(roles = listOf()))
         .exchange()
         .expectStatus().isForbidden
@@ -317,7 +317,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden with wrong role`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/nomis-adjustment-type/$nomisAdjustType/nomis-adjustment-id/$nomisAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
         .exchange()
         .expectStatus().isForbidden
@@ -326,7 +326,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     @Test
     fun `get mapping success`() {
 
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(BodyInserters.fromValue(createSentenceAdjustmentMapping()))
@@ -334,7 +334,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .expectStatus().isCreated
 
       val mapping =
-        webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
+        webTestClient.get().uri("/mapping/sentencing/adjustments/nomis-adjustment-type/$nomisAdjustType/nomis-adjustment-id/$nomisAdjustId")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
           .exchange()
           .expectStatus().isOk
@@ -350,7 +350,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `mapping not found`() {
-      val error = webTestClient.get().uri("/mapping/sentence-adjustments/sentence-adjustment-id/99999")
+      val error = webTestClient.get().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/99999")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNotFound
@@ -363,21 +363,21 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     @Test
     fun `get mapping success with update role`() {
 
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(BodyInserters.fromValue(createSentenceAdjustmentMapping()))
         .exchange()
         .expectStatus().isCreated
 
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/nomis-adjustment-type/$nomisAdjustType/nomis-adjustment-id/$nomisAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
     }
   }
 
-  @DisplayName("GET /mapping/sentence-adjustments/migrated/latest")
+  @DisplayName("GET /mapping/sentencing/adjustments/migrated/latest")
   @Nested
   inner class GeMappingMigratedLatestTest {
 
@@ -388,14 +388,14 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden when no authority`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/migrated/latest")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/migrated/latest")
         .exchange()
         .expectStatus().isUnauthorized
     }
 
     @Test
     fun `access forbidden when no role`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/migrated/latest")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/migrated/latest")
         .headers(setAuthorisation(roles = listOf()))
         .exchange()
         .expectStatus().isForbidden
@@ -403,7 +403,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden with wrong role`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/migrated/latest")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/migrated/latest")
         .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
         .exchange()
         .expectStatus().isForbidden
@@ -412,7 +412,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     @Test
     fun `get retrieves latest migrated mapping`() {
 
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(
@@ -429,7 +429,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isCreated
 
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(
@@ -446,7 +446,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isCreated
 
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(
@@ -463,7 +463,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isCreated
 
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(
@@ -480,7 +480,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isCreated
 
-      val mapping = webTestClient.get().uri("/mapping/sentence-adjustments/migrated/latest")
+      val mapping = webTestClient.get().uri("/mapping/sentencing/adjustments/migrated/latest")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
@@ -498,7 +498,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `404 when no migrated mapping found`() {
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(
@@ -515,7 +515,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isCreated
 
-      val error = webTestClient.get().uri("/mapping/sentence-adjustments/migrated/latest")
+      val error = webTestClient.get().uri("/mapping/sentencing/adjustments/migrated/latest")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNotFound
@@ -526,7 +526,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     }
   }
 
-  @DisplayName("GET /mapping/sentence-adjustments/sentence-adjustment-id/{sentenceAdjustId}")
+  @DisplayName("GET /mapping/sentencing/adjustments/sentence-adjustment-id/{sentenceAdjustId}")
   @Nested
   inner class GetSentenceAdjustmentMappingTest {
 
@@ -537,14 +537,14 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden when no authority`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/sentence-adjustment-id/$sentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/$sentenceAdjustId")
         .exchange()
         .expectStatus().isUnauthorized
     }
 
     @Test
     fun `access forbidden when no role`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/sentence-adjustment-id/$sentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/$sentenceAdjustId")
         .headers(setAuthorisation(roles = listOf()))
         .exchange()
         .expectStatus().isForbidden
@@ -552,7 +552,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden with wrong role`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/sentence-adjustment-id/$sentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/$sentenceAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
         .exchange()
         .expectStatus().isForbidden
@@ -561,14 +561,14 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     @Test
     fun `get mapping success`() {
 
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(BodyInserters.fromValue(createSentenceAdjustmentMapping()))
         .exchange()
         .expectStatus().isCreated
 
-      val mapping = webTestClient.get().uri("/mapping/sentence-adjustments/sentence-adjustment-id/$sentenceAdjustId")
+      val mapping = webTestClient.get().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/$sentenceAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
@@ -584,7 +584,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `mapping not found`() {
-      val error = webTestClient.get().uri("/mapping/sentence-adjustments/sentence-adjustment-id/765")
+      val error = webTestClient.get().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/765")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNotFound
@@ -597,34 +597,34 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     @Test
     fun `get mapping success with update role`() {
 
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(BodyInserters.fromValue(createSentenceAdjustmentMapping()))
         .exchange()
         .expectStatus().isCreated
 
-      webTestClient.get().uri("/mapping/sentence-adjustments/sentence-adjustment-id/$sentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/$sentenceAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
     }
   }
 
-  @DisplayName("DELETE /mapping/sentence-adjustments")
+  @DisplayName("DELETE /mapping/sentencing/adjustments")
   @Nested
   inner class DeleteMappingsTest {
 
     @Test
     fun `access forbidden when no authority`() {
-      webTestClient.delete().uri("/mapping/sentence-adjustments")
+      webTestClient.delete().uri("/mapping/sentencing/adjustments")
         .exchange()
         .expectStatus().isUnauthorized
     }
 
     @Test
     fun `access forbidden when no role`() {
-      webTestClient.delete().uri("/mapping/sentence-adjustments")
+      webTestClient.delete().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf()))
         .exchange()
         .expectStatus().isForbidden
@@ -632,7 +632,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden with wrong role`() {
-      webTestClient.delete().uri("/mapping/sentence-adjustments")
+      webTestClient.delete().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
         .exchange()
         .expectStatus().isForbidden
@@ -640,24 +640,24 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `delete mapping success`() {
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(BodyInserters.fromValue(createSentenceAdjustmentMapping()))
         .exchange()
         .expectStatus().isCreated
 
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/nomis-adjustment-type/$nomisAdjustType/nomis-adjustment-id/$nomisAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
 
-      webTestClient.delete().uri("/mapping/sentence-adjustments")
+      webTestClient.delete().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNoContent
 
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/nomis-adjustment-type/$nomisAdjustType/nomis-adjustment-id/$nomisAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNotFound
@@ -665,14 +665,14 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `delete incentive mappings - migrated mappings only`() {
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(BodyInserters.fromValue(createSentenceAdjustmentMapping()))
         .exchange()
         .expectStatus().isCreated
 
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(
@@ -688,37 +688,37 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isCreated
 
-      webTestClient.delete().uri("/mapping/sentence-adjustments?onlyMigrated=true")
+      webTestClient.delete().uri("/mapping/sentencing/adjustments?onlyMigrated=true")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNoContent
 
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/nomis-adjustment-type/$nomisAdjustType/nomis-adjustment-id/$nomisAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
 
-      webTestClient.get().uri("/mapping/sentence-adjustments/sentence-adjustment-id/222/nomis-adjustment-type/$nomisAdjustType")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/nomis-adjustment-type/$nomisAdjustType/sentence-adjustment-id/222")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNotFound
     }
   }
 
-  @DisplayName("DELETE /mapping/sentence-adjustments/sentence-adjustment-id/{sentenceAdjustId}")
+  @DisplayName("DELETE /mapping/sentencing/adjustments/sentence-adjustment-id/{sentenceAdjustId}")
   @Nested
   inner class DeleteMappingTest {
 
     @Test
     fun `access forbidden when no authority`() {
-      webTestClient.delete().uri("/mapping/sentence-adjustments/sentence-adjustment-id/999")
+      webTestClient.delete().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/999")
         .exchange()
         .expectStatus().isUnauthorized
     }
 
     @Test
     fun `access forbidden when no role`() {
-      webTestClient.delete().uri("/mapping/sentence-adjustments/sentence-adjustment-id/999")
+      webTestClient.delete().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/999")
         .headers(setAuthorisation(roles = listOf()))
         .exchange()
         .expectStatus().isForbidden
@@ -726,7 +726,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden with wrong role`() {
-      webTestClient.delete().uri("/mapping/sentence-adjustments/sentence-adjustment-id/999")
+      webTestClient.delete().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/999")
         .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
         .exchange()
         .expectStatus().isForbidden
@@ -735,7 +735,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     @Test
     fun `delete specific mapping success`() {
       // create mapping
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(BodyInserters.fromValue(createSentenceAdjustmentMapping()))
@@ -743,29 +743,29 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .expectStatus().isCreated
 
       // it is present after creation by incentive id
-      webTestClient.get().uri("/mapping/sentence-adjustments/sentence-adjustment-id/$sentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/$sentenceAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
       // it is also present after creation by nomis id
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/nomis-adjustment-type/$nomisAdjustType/nomis-adjustment-id/$nomisAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
 
       // delete mapping
-      webTestClient.delete().uri("/mapping/sentence-adjustments/sentence-adjustment-id/$sentenceAdjustId")
+      webTestClient.delete().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/$sentenceAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNoContent
 
       // no longer present by incentive id
-      webTestClient.get().uri("/mapping/sentence-adjustments/sentence-adjustment-id/$sentenceAdjustId")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/$sentenceAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNotFound
       // and also no longer present by nomis id
-      webTestClient.get().uri("/mapping/sentence-adjustments/nomis-adjustment-id/$nomisAdjustId/nomis-adjustment-type/$nomisAdjustType")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/nomis-adjustment-type/$nomisAdjustType/nomis-adjustment-id/$nomisAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNotFound
@@ -774,7 +774,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
     @Test
     internal fun `delete is idempotent`() {
       // create mapping
-      webTestClient.post().uri("/mapping/sentence-adjustments")
+      webTestClient.post().uri("/mapping/sentencing/adjustments")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .contentType(MediaType.APPLICATION_JSON)
         .body(BodyInserters.fromValue(createSentenceAdjustmentMapping()))
@@ -782,19 +782,19 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         .expectStatus().isCreated
 
       // delete mapping
-      webTestClient.delete().uri("/mapping/sentence-adjustments/sentence-adjustment-id/$sentenceAdjustId")
+      webTestClient.delete().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/$sentenceAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNoContent
       // delete mapping second time still returns success
-      webTestClient.delete().uri("/mapping/sentence-adjustments/sentence-adjustment-id/$sentenceAdjustId")
+      webTestClient.delete().uri("/mapping/sentencing/adjustments/sentence-adjustment-id/$sentenceAdjustId")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isNoContent
     }
   }
 
-  @DisplayName("GET /mapping/sentence-adjustments/migration-id/{migrationId}")
+  @DisplayName("GET /mapping/sentencing/adjustments/migration-id/{migrationId}")
   @Nested
   inner class GetMappingByMigrationIdTest {
 
@@ -805,14 +805,14 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden when no authority`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/migration-id/2022-01-01T00:00:00")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/migration-id/2022-01-01T00:00:00")
         .exchange()
         .expectStatus().isUnauthorized
     }
 
     @Test
     fun `access forbidden when no role`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/migration-id/2022-01-01T00:00:00")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/migration-id/2022-01-01T00:00:00")
         .headers(setAuthorisation(roles = listOf()))
         .exchange()
         .expectStatus().isForbidden
@@ -820,7 +820,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
 
     @Test
     fun `get sentence adjustment mappings by migration id forbidden with wrong role`() {
-      webTestClient.get().uri("/mapping/sentence-adjustments/migration-id/2022-01-01T00:00:00")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/migration-id/2022-01-01T00:00:00")
         .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
         .exchange()
         .expectStatus().isForbidden
@@ -853,7 +853,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         sentenceAdjustmentId = 12, mappingType = SENTENCING_CREATED.name
       )
 
-      webTestClient.get().uri("/mapping/sentence-adjustments/migration-id/2022-01-01")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/migration-id/2022-01-01")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
@@ -880,7 +880,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         )
       }
 
-      webTestClient.get().uri("/mapping/sentence-adjustments/migration-id/2044-01-01")
+      webTestClient.get().uri("/mapping/sentencing/adjustments/migration-id/2044-01-01")
         .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_SENTENCING")))
         .exchange()
         .expectStatus().isOk
@@ -902,7 +902,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         )
       }
       webTestClient.get().uri {
-        it.path("/mapping/sentence-adjustments/migration-id/2022-01-01")
+        it.path("/mapping/sentencing/adjustments/migration-id/2022-01-01")
           .queryParam("size", "2")
           .queryParam("sort", "nomisAdjustmentId,asc")
           .build()
@@ -930,7 +930,7 @@ class SentenceAdjustmentMappingResourceIntTest : IntegrationTestBase() {
         )
       }
       webTestClient.get().uri {
-        it.path("/mapping/sentence-adjustments/migration-id/2022-01-01")
+        it.path("/mapping/sentencing/adjustments/migration-id/2022-01-01")
           .queryParam("size", "2")
           .queryParam("page", "1")
           .queryParam("sort", "nomisAdjustmentId,asc")


### PR DESCRIPTION
The same table and endpoints with be used for both sentence and booking level adjustments. In NOMIS this is 2 tables but 1 entity in the DPS service

URL now /mapping/sentencing/adjustments/