### PR TITLE
SDIT-942: Delete appointment mappings by migration id

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/jpa/repository/AppointmentMappingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/jpa/repository/AppointmentMappingRepository.kt
@@ -21,5 +21,5 @@ interface AppointmentMappingRepository : CoroutineCrudRepository<AppointmentMapp
     pageable: Pageable,
   ): Flow<AppointmentMapping>
 
-  suspend fun deleteByMappingType(mappingType: AppointmentMappingType)
+  suspend fun deleteByLabel(label: String)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/resource/AppointmentMappingResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/resource/AppointmentMappingResource.kt
@@ -192,15 +192,15 @@ class AppointmentMappingResource(private val mappingService: AppointmentMappingS
   ) = mappingService.deleteMapping(id)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_APPOINTMENTS')")
-  @DeleteMapping("/mapping/appointments/migrations")
+  @DeleteMapping("/mapping/appointments/migration-id/{migrationId}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @Operation(
-    summary = "Deletes all migration mappings",
+    summary = "Delete appointment mapping entries for the supplied migration id",
     description = "To be used when re-running migrations. Note this will not touch any appointments, just the mappings.",
     responses = [
       ApiResponse(
         responseCode = "204",
-        description = "Mappings deleted",
+        description = "Appointments migration mapping id mappings deleted",
       ),
       ApiResponse(
         responseCode = "401",
@@ -208,13 +208,17 @@ class AppointmentMappingResource(private val mappingService: AppointmentMappingS
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
       ApiResponse(
-        description = "Insufficient priveleges - requires role NOMIS_APPOINTMENTS",
+        description = "Insufficient privileges - requires role NOMIS_APPOINTMENTS",
         responseCode = "403",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
     ],
   )
-  suspend fun deleteMigrationMappings() = mappingService.deleteMigrationMappings()
+  suspend fun deleteAppointmentMigrationMappingsByMigrationId(
+    @Schema(description = "Migration Id", example = "2023-06-24T12:00:00", required = true)
+    @PathVariable
+    migrationId: String,
+  ) = mappingService.deleteAppointmentMappingsByMigrationId(migrationId)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_APPOINTMENTS')")
   @GetMapping("/mapping/appointments/migration-id/{migrationId}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/service/AppointmentMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/service/AppointmentMappingService.kt
@@ -133,7 +133,7 @@ class AppointmentMappingService(
     appointmentMappingRepository.findAll().toList().map { AppointmentMappingDto(it) }
 
   @Transactional
-  suspend fun deleteMigrationMappings() {
-    appointmentMappingRepository.deleteByMappingType(AppointmentMappingType.MIGRATED)
+  suspend fun deleteAppointmentMappingsByMigrationId(migrationId: String) {
+    appointmentMappingRepository.deleteByLabel(migrationId)
   }
 }


### PR DESCRIPTION
This replaces the endpoint that deleted all migration mappings with a more targeted version. The delete all endpoint could not have been used after the first successful prod migration.