### PR TITLE
SDIT-1496 Add alert mapping functionality

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMapping.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMapping.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.alerts
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.Transient
+import org.springframework.data.domain.Persistable
+import java.time.LocalDateTime
+
+data class AlertMapping(
+
+  @Id
+  val dpsAlertId: String,
+
+  val nomisBookingId: Long,
+  val nomisAlertSequence: Long,
+
+  /**
+   * ISO timestamp of batch job if a migration
+   */
+  val label: String? = null,
+
+  val mappingType: AlertMappingType,
+
+  @Transient
+  @Value("false")
+  val new: Boolean = true,
+
+  val whenCreated: LocalDateTime? = null,
+
+) : Persistable<String> {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is AlertMapping) return false
+
+    if (dpsAlertId != other.dpsAlertId) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    return dpsAlertId.hashCode()
+  }
+
+  override fun isNew(): Boolean = new
+
+  override fun getId(): String = dpsAlertId
+}
+
+enum class AlertMappingType {
+  MIGRATED,
+  DPS_CREATED,
+  NOMIS_CREATED,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingDto.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.alerts
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "NOMIS to Alert mapping")
+data class AlertMappingDto(
+  @Schema(description = "DPS alert id")
+  val dpsAlertId: String,
+
+  @Schema(description = "NOMIS booking id")
+  val nomisBookingId: Long,
+
+  @Schema(description = "NOMIS alert sequence")
+  val nomisAlertSequence: Long,
+
+  @Schema(description = "Label (a timestamp for migrated ids)")
+  val label: String? = null,
+
+  @Schema(description = "Mapping type", allowableValues = ["MIGRATED", "NOMIS_CREATED", "DPS_CREATED"])
+  val mappingType: AlertMappingType,
+
+  @Schema(description = "Date time the mapping was created")
+  val whenCreated: LocalDateTime? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingService.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.alerts
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.service.NotFoundException
+
+@Service
+class AlertMappingService(val repository: AlertsMappingRepository) {
+  suspend fun getMappingByNomisId(bookingId: Long, alertSequence: Long): AlertMappingDto {
+    return repository.findOneByNomisBookingIdAndNomisAlertSequence(bookingId = bookingId, alertSequence = alertSequence)
+      ?.let {
+        AlertMappingDto(
+          nomisBookingId = it.nomisBookingId,
+          nomisAlertSequence = it.nomisAlertSequence,
+          dpsAlertId = it.dpsAlertId,
+          label = it.label,
+          mappingType = it.mappingType,
+          whenCreated = it.whenCreated,
+        )
+      } ?: throw NotFoundException("No alert mapping found for bookingId=$bookingId,alertSequence=$alertSequence")
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertsMappingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertsMappingRepository.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.alerts
+
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+
+@Suppress("SpringDataRepositoryMethodReturnTypeInspection")
+@Repository
+interface AlertsMappingRepository : CoroutineCrudRepository<AlertMapping, String> {
+  suspend fun findOneByNomisBookingIdAndNomisAlertSequence(bookingId: Long, alertSequence: Long): AlertMapping?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertsMappingResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertsMappingResource.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.alerts
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.config.ErrorResponse
+
+@RestController
+@Validated
+@RequestMapping("/mapping/alerts", produces = [MediaType.APPLICATION_JSON_VALUE])
+class AlertsMappingResource(private val mappingService: AlertMappingService) {
+  @PreAuthorize("hasRole('NOMIS_ALERTS')")
+  @GetMapping("/nomis-booking-id/{bookingId}/nomis-alert-sequence/{alertSequence}")
+  @Operation(
+    summary = "get mapping",
+    description = "Retrieves a mapping by NOMIS id. Requires role NOMIS_ALERTS",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Mapping Information Returned",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = AlertMappingDto::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Id does not exist in mapping table",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  suspend fun getMappingByNomisId(
+    @Schema(description = "NOMIS booking id", example = "12345", required = true)
+    @PathVariable
+    bookingId: Long,
+    @Schema(description = "NOMIS booking id", example = "2", required = true)
+    @PathVariable
+    alertSequence: Long,
+  ): AlertMappingDto = mappingService.getMappingByNomisId(bookingId = bookingId, alertSequence = alertSequence)
+}

--- a/src/main/resources/db/migration/V1_37__alert.sql
+++ b/src/main/resources/db/migration/V1_37__alert.sql
@@ -1,0 +1,12 @@
+create table alert_mapping
+(
+    dps_alert_id         varchar(36)              not null PRIMARY KEY,
+    nomis_booking_id     bigint                   not null,
+    nomis_alert_sequence bigint                   not null,
+    when_created         timestamp with time zone not null default now(),
+    label                varchar(20),
+    mapping_type         varchar(20)              not null,
+    constraint alert_mapping_nomis_id_unique unique (nomis_booking_id, nomis_alert_sequence)
+);
+create index alert_mapping_when_created_index on alert_mapping (when_created);
+create index alert_mapping_label_index on alert_mapping (label);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingResourceIntTest.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.alerts
+
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.alerts.AlertMappingType.MIGRATED
+import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.integration.IntegrationTestBase
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+class AlertMappingResourceIntTest : IntegrationTestBase() {
+  @Autowired
+  private lateinit var repository: AlertsMappingRepository
+
+  @Nested
+  @DisplayName("GET /mapping/alerts/nomis-booking-id/{bookingId}/nomis-alert-sequence/{alertSequence}")
+  inner class GetMappingByNomisId {
+    lateinit var mapping: AlertMapping
+
+    @BeforeEach
+    fun setUp() = runTest {
+      mapping = repository.save(
+        AlertMapping(
+          dpsAlertId = "edcd118c-41ba-42ea-b5c4-404b453ad58b",
+          nomisBookingId = 54321L,
+          nomisAlertSequence = 2L,
+          label = "2023-01-01T12:45:12",
+          mappingType = MIGRATED,
+        ),
+      )
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+      repository.deleteAll()
+    }
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no authority`() {
+        webTestClient.get()
+          .uri("/mapping/alerts/nomis-booking-id/${mapping.nomisBookingId}/nomis-alert-sequence/${mapping.nomisAlertSequence}")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.get()
+          .uri("/mapping/alerts/nomis-booking-id/${mapping.nomisBookingId}/nomis-alert-sequence/${mapping.nomisAlertSequence}")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `create visit forbidden with wrong role`() {
+        webTestClient.get()
+          .uri("/mapping/alerts/nomis-booking-id/${mapping.nomisBookingId}/nomis-alert-sequence/${mapping.nomisAlertSequence}")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `will return 404 when mapping does not exist`() {
+        webTestClient.get()
+          .uri("/mapping/alerts/nomis-booking-id/9999/nomis-alert-sequence/${mapping.nomisAlertSequence}")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .exchange()
+          .expectStatus().isNotFound
+      }
+
+      @Test
+      fun `will return 200 when mapping does exist`() {
+        webTestClient.get()
+          .uri("/mapping/alerts/nomis-booking-id/${mapping.nomisBookingId}/nomis-alert-sequence/${mapping.nomisAlertSequence}")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("nomisBookingId").isEqualTo(mapping.nomisBookingId)
+          .jsonPath("nomisAlertSequence").isEqualTo(mapping.nomisAlertSequence)
+          .jsonPath("dpsAlertId").isEqualTo(mapping.dpsAlertId)
+          .jsonPath("mappingType").isEqualTo(mapping.mappingType.name)
+          .jsonPath("label").isEqualTo(mapping.label!!)
+          .jsonPath("whenCreated").value<String> {
+            assertThat(LocalDateTime.parse(it)).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS))
+          }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces new alert mapping functionality by adding a new data model (`AlertMapping`), database migration scripts, a repository (`AlertMappingRepository`), a service (`AlertMappingService`), and a controller (`AlertsMappingResource`). Additionally, it includes a DTO to serve over the API (`AlertMappingDto`) and integration tests to validate the added setup. The alert mapping is done based on NOMIS ID and NOMIS alert sequence.

Used more standard int test and package structure in tune with other sync services