### PR TITLE
SDIT-1496 Create alert mapping functionality

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingDto.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.alerts
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.alerts.AlertMappingType.DPS_CREATED
 import java.time.LocalDateTime
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -20,7 +21,7 @@ data class AlertMappingDto(
   val label: String? = null,
 
   @Schema(description = "Mapping type", allowableValues = ["MIGRATED", "NOMIS_CREATED", "DPS_CREATED"])
-  val mappingType: AlertMappingType,
+  val mappingType: AlertMappingType = DPS_CREATED,
 
   @Schema(description = "Date time the mapping was created")
   val whenCreated: LocalDateTime? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingService.kt
@@ -5,8 +5,8 @@ import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.service.NotFoundEx
 
 @Service
 class AlertMappingService(val repository: AlertsMappingRepository) {
-  suspend fun getMappingByNomisId(bookingId: Long, alertSequence: Long): AlertMappingDto {
-    return repository.findOneByNomisBookingIdAndNomisAlertSequence(bookingId = bookingId, alertSequence = alertSequence)
+  suspend fun getMappingByNomisId(bookingId: Long, alertSequence: Long) =
+    repository.findOneByNomisBookingIdAndNomisAlertSequence(bookingId = bookingId, alertSequence = alertSequence)
       ?.let {
         AlertMappingDto(
           nomisBookingId = it.nomisBookingId,
@@ -17,5 +17,29 @@ class AlertMappingService(val repository: AlertsMappingRepository) {
           whenCreated = it.whenCreated,
         )
       } ?: throw NotFoundException("No alert mapping found for bookingId=$bookingId,alertSequence=$alertSequence")
+
+  suspend fun getMappingByDpsId(alertId: String) =
+    repository.findOneByDpsAlertId(dpsAlertId = alertId)
+      ?.let {
+        AlertMappingDto(
+          nomisBookingId = it.nomisBookingId,
+          nomisAlertSequence = it.nomisAlertSequence,
+          dpsAlertId = it.dpsAlertId,
+          label = it.label,
+          mappingType = it.mappingType,
+          whenCreated = it.whenCreated,
+        )
+      } ?: throw NotFoundException("No alert mapping found for dpsAlertId=$alertId")
+
+  suspend fun createMapping(mapping: AlertMappingDto) {
+    repository.save(
+      AlertMapping(
+        dpsAlertId = mapping.dpsAlertId,
+        nomisBookingId = mapping.nomisBookingId,
+        nomisAlertSequence = mapping.nomisAlertSequence,
+        label = mapping.label,
+        mappingType = mapping.mappingType,
+      ),
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingService.kt
@@ -7,39 +7,32 @@ import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.service.NotFoundEx
 class AlertMappingService(val repository: AlertsMappingRepository) {
   suspend fun getMappingByNomisId(bookingId: Long, alertSequence: Long) =
     repository.findOneByNomisBookingIdAndNomisAlertSequence(bookingId = bookingId, alertSequence = alertSequence)
-      ?.let {
-        AlertMappingDto(
-          nomisBookingId = it.nomisBookingId,
-          nomisAlertSequence = it.nomisAlertSequence,
-          dpsAlertId = it.dpsAlertId,
-          label = it.label,
-          mappingType = it.mappingType,
-          whenCreated = it.whenCreated,
-        )
-      } ?: throw NotFoundException("No alert mapping found for bookingId=$bookingId,alertSequence=$alertSequence")
+      ?.toDto()
+      ?: throw NotFoundException("No alert mapping found for bookingId=$bookingId,alertSequence=$alertSequence")
 
   suspend fun getMappingByDpsId(alertId: String) =
     repository.findOneByDpsAlertId(dpsAlertId = alertId)
-      ?.let {
-        AlertMappingDto(
-          nomisBookingId = it.nomisBookingId,
-          nomisAlertSequence = it.nomisAlertSequence,
-          dpsAlertId = it.dpsAlertId,
-          label = it.label,
-          mappingType = it.mappingType,
-          whenCreated = it.whenCreated,
-        )
-      } ?: throw NotFoundException("No alert mapping found for dpsAlertId=$alertId")
+      ?.toDto()
+      ?: throw NotFoundException("No alert mapping found for dpsAlertId=$alertId")
 
   suspend fun createMapping(mapping: AlertMappingDto) {
-    repository.save(
-      AlertMapping(
-        dpsAlertId = mapping.dpsAlertId,
-        nomisBookingId = mapping.nomisBookingId,
-        nomisAlertSequence = mapping.nomisAlertSequence,
-        label = mapping.label,
-        mappingType = mapping.mappingType,
-      ),
-    )
+    repository.save(mapping.fromDto())
   }
 }
+
+fun AlertMapping.toDto() = AlertMappingDto(
+  nomisBookingId = nomisBookingId,
+  nomisAlertSequence = nomisAlertSequence,
+  dpsAlertId = dpsAlertId,
+  label = label,
+  mappingType = mappingType,
+  whenCreated = whenCreated,
+)
+
+fun AlertMappingDto.fromDto() = AlertMapping(
+  dpsAlertId = dpsAlertId,
+  nomisBookingId = nomisBookingId,
+  nomisAlertSequence = nomisAlertSequence,
+  label = label,
+  mappingType = mappingType,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertsMappingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertsMappingRepository.kt
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository
 @Repository
 interface AlertsMappingRepository : CoroutineCrudRepository<AlertMapping, String> {
   suspend fun findOneByNomisBookingIdAndNomisAlertSequence(bookingId: Long, alertSequence: Long): AlertMapping?
+  suspend fun findOneByDpsAlertId(dpsAlertId: String): AlertMapping?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertsMappingResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertsMappingResource.kt
@@ -4,20 +4,28 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.config.DuplicateMappingErrorResponse
+import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.config.DuplicateMappingException
 import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.config.ErrorResponse
 
 @RestController
 @Validated
+@PreAuthorize("hasRole('NOMIS_ALERTS')")
 @RequestMapping("/mapping/alerts", produces = [MediaType.APPLICATION_JSON_VALUE])
 class AlertsMappingResource(private val mappingService: AlertMappingService) {
-  @PreAuthorize("hasRole('NOMIS_ALERTS')")
   @GetMapping("/nomis-booking-id/{bookingId}/nomis-alert-sequence/{alertSequence}")
   @Operation(
     summary = "get mapping",
@@ -50,4 +58,62 @@ class AlertsMappingResource(private val mappingService: AlertMappingService) {
     @PathVariable
     alertSequence: Long,
   ): AlertMappingDto = mappingService.getMappingByNomisId(bookingId = bookingId, alertSequence = alertSequence)
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  @Operation(
+    summary = "Creates a new alert mapping",
+    description = "Creates a mapping between nomis Incentive ids and Incentive service id. Requires ROLE_NOMIS_ALERTS",
+    requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
+      content = [Content(mediaType = "application/json", schema = Schema(implementation = AlertMappingDto::class))],
+    ),
+    responses = [
+      ApiResponse(responseCode = "201", description = "Mapping created"),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Access forbidden for this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "409",
+        description = "Indicates a duplicate mapping has been rejected. If Error code = 1409 the body will return a DuplicateErrorResponse",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = DuplicateMappingErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  suspend fun createMapping(
+    @RequestBody @Valid
+    mapping: AlertMappingDto,
+  ) =
+    try {
+      mappingService.createMapping(mapping)
+    } catch (e: DuplicateKeyException) {
+      throw DuplicateMappingException(
+        messageIn = "Alert mapping already exists",
+        duplicate = mapping,
+        existing = getExistingMappingSimilarTo(mapping),
+        cause = e,
+      )
+    }
+
+  private suspend fun getExistingMappingSimilarTo(mapping: AlertMappingDto) = runCatching {
+    mappingService.getMappingByNomisId(
+      bookingId = mapping.nomisBookingId,
+      alertSequence = mapping.nomisAlertSequence,
+    )
+  }.getOrElse {
+    mappingService.getMappingByDpsId(
+      alertId = mapping.dpsAlertId,
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingResourceIntTest.kt
@@ -9,10 +9,15 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.BodyInserters
 import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.alerts.AlertMappingType.MIGRATED
+import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.helper.TestDuplicateErrorResponse
 import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.integration.IntegrationTestBase
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
+import java.util.UUID
 
 class AlertMappingResourceIntTest : IntegrationTestBase() {
   @Autowired
@@ -97,6 +102,327 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
           .jsonPath("whenCreated").value<String> {
             assertThat(LocalDateTime.parse(it)).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS))
           }
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("POST /mapping/alerts")
+  inner class CreateMapping {
+    private lateinit var existingMapping: AlertMapping
+    private val mapping = AlertMappingDto(
+      dpsAlertId = "e52d7268-6e10-41a8-a0b9-2319b32520d6",
+      nomisBookingId = 54321L,
+      nomisAlertSequence = 3L,
+      label = "2023-01-01T12:45:12",
+      mappingType = MIGRATED,
+    )
+
+    @BeforeEach
+    fun setUp() = runTest {
+      existingMapping = repository.save(
+        AlertMapping(
+          dpsAlertId = "edcd118c-41ba-42ea-b5c4-404b453ad58b",
+          nomisBookingId = 54321L,
+          nomisAlertSequence = 2L,
+          label = "2023-01-01T12:45:12",
+          mappingType = MIGRATED,
+        ),
+      )
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+      repository.deleteAll()
+    }
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access not authorised when no authority`() {
+        webTestClient.post()
+          .uri("/mapping/alerts")
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(mapping))
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.post()
+          .uri("/mapping/alerts")
+          .headers(setAuthorisation(roles = listOf()))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(mapping))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.post()
+          .uri("/mapping/alerts")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(mapping))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `returns 201 when mapping created`() = runTest {
+        webTestClient.post()
+          .uri("/mapping/alerts")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(mapping))
+          .exchange()
+          .expectStatus().isCreated
+
+        val createdMapping =
+          repository.findOneByNomisBookingIdAndNomisAlertSequence(
+            bookingId = mapping.nomisBookingId,
+            alertSequence = mapping.nomisAlertSequence,
+          )!!
+
+        assertThat(createdMapping.whenCreated).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS))
+        assertThat(createdMapping.nomisBookingId).isEqualTo(mapping.nomisBookingId)
+        assertThat(createdMapping.nomisAlertSequence).isEqualTo(mapping.nomisAlertSequence)
+        assertThat(createdMapping.dpsAlertId).isEqualTo(mapping.dpsAlertId)
+        assertThat(createdMapping.mappingType).isEqualTo(mapping.mappingType)
+        assertThat(createdMapping.label).isEqualTo(mapping.label)
+      }
+
+      @Test
+      fun `can create with minimal data`() = runTest {
+        webTestClient.post()
+          .uri("/mapping/alerts")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              //language=JSON
+              """
+                {
+                  "nomisBookingId": 54321,
+                  "nomisAlertSequence": 3,
+                  "dpsAlertId": "e52d7268-6e10-41a8-a0b9-2319b32520d6"
+                }
+              """.trimIndent(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isCreated
+
+        val createdMapping =
+          repository.findOneByNomisBookingIdAndNomisAlertSequence(
+            bookingId = 54321,
+            alertSequence = 3,
+          )!!
+
+        assertThat(createdMapping.whenCreated).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS))
+        assertThat(createdMapping.nomisBookingId).isEqualTo(54321L)
+        assertThat(createdMapping.nomisAlertSequence).isEqualTo(3L)
+        assertThat(createdMapping.dpsAlertId).isEqualTo("e52d7268-6e10-41a8-a0b9-2319b32520d6")
+        assertThat(createdMapping.mappingType).isEqualTo(AlertMappingType.DPS_CREATED)
+        assertThat(createdMapping.label).isNull()
+      }
+
+      @Test
+      fun `can post and then get new and existing mapping`() {
+        webTestClient.post()
+          .uri("/mapping/alerts")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              //language=JSON
+              """
+                {
+                  "nomisBookingId": 54321,
+                  "nomisAlertSequence": 3,
+                  "dpsAlertId": "e52d7268-6e10-41a8-a0b9-2319b32520d6"
+                }
+              """.trimIndent(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isCreated
+
+        webTestClient.get()
+          .uri("/mapping/alerts/nomis-booking-id/54321/nomis-alert-sequence/3")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .exchange()
+          .expectStatus().isOk
+
+        webTestClient.get()
+          .uri("/mapping/alerts/nomis-booking-id/${existingMapping.nomisBookingId}/nomis-alert-sequence/${existingMapping.nomisAlertSequence}")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .exchange()
+          .expectStatus().isOk
+      }
+    }
+
+    @Nested
+    inner class Validation {
+      @Test
+      fun `returns 400 when mapping type is invalid`() {
+        webTestClient.post()
+          .uri("/mapping/alerts")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              //language=JSON
+              """
+                {
+                  "nomisBookingId": 54321,
+                  "nomisAlertSequence": 3,
+                  "dpsAlertId": "e52d7268-6e10-41a8-a0b9-2319b32520d6",
+                  "mappingType": "INVALID_TYPE"
+                }
+              """.trimIndent(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isBadRequest
+      }
+
+      @Test
+      fun `returns 400 when DPS id is missing`() {
+        webTestClient.post()
+          .uri("/mapping/alerts")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              //language=JSON
+              """
+                {
+                  "nomisBookingId": 54321,
+                  "nomisAlertSequence": 3
+                }
+              """.trimIndent(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isBadRequest
+      }
+
+      @Test
+      fun `returns 400 when NOMIS ids are missing`() {
+        webTestClient.post()
+          .uri("/mapping/alerts")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              //language=JSON
+              """
+                {
+                  "nomisAlertSequence": 3,
+                  "dpsAlertId": "e52d7268-6e10-41a8-a0b9-2319b32520d6"
+                }
+              """.trimIndent(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isBadRequest
+
+        webTestClient.post()
+          .uri("/mapping/alerts")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              //language=JSON
+              """
+                {
+                  "nomisBookingId": 54321,
+                  "dpsAlertId": "e52d7268-6e10-41a8-a0b9-2319b32520d6"
+                }
+              """.trimIndent(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isBadRequest
+      }
+
+      @Test
+      fun `returns 409 if nomis ids already exist`() {
+        val dpsAlertId = UUID.randomUUID().toString()
+        val duplicateResponse = webTestClient.post()
+          .uri("/mapping/alerts")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              AlertMappingDto(
+                nomisBookingId = existingMapping.nomisBookingId,
+                nomisAlertSequence = existingMapping.nomisAlertSequence,
+                dpsAlertId = dpsAlertId,
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isEqualTo(409)
+          .expectBody(
+            object :
+              ParameterizedTypeReference<TestDuplicateErrorResponse>() {},
+          )
+          .returnResult().responseBody
+
+        with(duplicateResponse!!) {
+          // since this is an untyped map an int will be assumed for such small numbers
+          assertThat(this.moreInfo.existing)
+            .containsEntry("nomisBookingId", existingMapping.nomisBookingId.toInt())
+            .containsEntry("nomisAlertSequence", existingMapping.nomisAlertSequence.toInt())
+            .containsEntry("dpsAlertId", existingMapping.dpsAlertId)
+          assertThat(this.moreInfo.duplicate)
+            .containsEntry("nomisBookingId", existingMapping.nomisBookingId.toInt())
+            .containsEntry("nomisAlertSequence", existingMapping.nomisAlertSequence.toInt())
+            .containsEntry("dpsAlertId", dpsAlertId)
+        }
+      }
+
+      @Test
+      fun `returns 409 if dps id already exist`() {
+        val duplicateResponse = webTestClient.post()
+          .uri("/mapping/alerts")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              AlertMappingDto(
+                nomisBookingId = existingMapping.nomisBookingId,
+                nomisAlertSequence = 99,
+                dpsAlertId = existingMapping.dpsAlertId,
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isEqualTo(409)
+          .expectBody(
+            object :
+              ParameterizedTypeReference<TestDuplicateErrorResponse>() {},
+          )
+          .returnResult().responseBody
+
+        with(duplicateResponse!!) {
+          // since this is an untyped map an int will be assumed for such small numbers
+          assertThat(this.moreInfo.existing)
+            .containsEntry("nomisBookingId", existingMapping.nomisBookingId.toInt())
+            .containsEntry("nomisAlertSequence", existingMapping.nomisAlertSequence.toInt())
+            .containsEntry("dpsAlertId", existingMapping.dpsAlertId)
+          assertThat(this.moreInfo.duplicate)
+            .containsEntry("nomisBookingId", existingMapping.nomisBookingId.toInt())
+            .containsEntry("nomisAlertSequence", 99)
+            .containsEntry("dpsAlertId", existingMapping.dpsAlertId)
+        }
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/helper/Data.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/helper/Data.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.helper
+
+// Update sync service reads as if these are Maps
+class TestDuplicateErrorResponse(
+  val moreInfo: TestDuplicateErrorContent,
+)
+
+data class TestDuplicateErrorContent(
+  val duplicate: Map<String, *>,
+  val existing: Map<String, *>? = null,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/resource/PunishmentsMappingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/resource/PunishmentsMappingResourceIntTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.data.AdjudicationP
 import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.data.AdjudicationPunishmentBatchUpdateMappingDto
 import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.data.AdjudicationPunishmentMappingDto
 import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.data.AdjudicationPunishmentNomisIdDto
+import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.helper.TestDuplicateErrorResponse
 import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.integration.isDuplicateMapping
 import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.jpa.AdjudicationMappingType.ADJUDICATION_CREATED
@@ -685,13 +686,3 @@ class PunishmentsMappingResourceIntTest : IntegrationTestBase() {
     }
   }
 }
-
-// Update sync service reads as if these are Maps
-class TestDuplicateErrorResponse(
-  val moreInfo: TestDuplicateErrorContent,
-)
-
-data class TestDuplicateErrorContent(
-  val duplicate: Map<String, *>,
-  val existing: Map<String, *>? = null,
-)


### PR DESCRIPTION
A few pattern changes on all the existing mappings:

- Always return existing mapping for all duplicate scenarios (others do not return existing for duplicate keys)
- Rely solely on duplicate key exceptions for both duplicate scenarios 
- Standardise test patterns to be consistent with other sync services