### PR TITLE
SDIT-1658 New version of alerts by prisoner POST and get by migrationId

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingDto.kt
@@ -17,6 +17,9 @@ data class AlertMappingDto(
   @Schema(description = "NOMIS alert sequence")
   val nomisAlertSequence: Long,
 
+  @Schema(description = "Prisoner number")
+  val offenderNo: String?,
+
   @Schema(description = "Label (a timestamp for migrated ids)")
   val label: String? = null,
 
@@ -25,4 +28,43 @@ data class AlertMappingDto(
 
   @Schema(description = "Date time the mapping was created")
   val whenCreated: LocalDateTime? = null,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Summary of mappings for a prisoner created during migration")
+data class PrisonerAlertMappingsSummaryDto(
+  @Schema(description = "The prisoner number for the set of mappings")
+  val offenderNo: String,
+
+  @Schema(description = "Count of the number mappings migrated (does not include subsequent alerts synchronised")
+  val mappingsCount: Int,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Mappings for a prisoner created during migration")
+data class PrisonerAlertMappingsDto(
+  @Schema(description = "Label (a timestamp for migrated ids)")
+  val label: String? = null,
+
+  @Schema(description = "Mapping type")
+  val mappingType: AlertMappingType = DPS_CREATED,
+
+  @Schema(description = "Date time the mapping was created")
+  val whenCreated: LocalDateTime? = null,
+
+  @Schema(description = "Mapping IDs")
+  val mappings: List<AlertMappingIdDto>,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "NOMIS to Alert mapping IDs")
+data class AlertMappingIdDto(
+  @Schema(description = "DPS alert id")
+  val dpsAlertId: String,
+
+  @Schema(description = "NOMIS booking id")
+  val nomisBookingId: Long,
+
+  @Schema(description = "NOMIS alert sequence")
+  val nomisAlertSequence: Long,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertPrisonerMapping.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertPrisonerMapping.kt
@@ -6,14 +6,12 @@ import org.springframework.data.annotation.Transient
 import org.springframework.data.domain.Persistable
 import java.time.LocalDateTime
 
-data class AlertMapping(
+data class AlertPrisonerMapping(
 
   @Id
-  val dpsAlertId: String,
+  val offenderNo: String,
 
-  val nomisBookingId: Long,
-  val nomisAlertSequence: Long,
-  val offenderNo: String?,
+  val count: Int,
 
   /**
    * ISO timestamp of batch job if a migration
@@ -32,24 +30,18 @@ data class AlertMapping(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other !is AlertMapping) return false
+    if (other !is AlertPrisonerMapping) return false
 
-    if (dpsAlertId != other.dpsAlertId) return false
+    if (offenderNo != other.offenderNo) return false
 
     return true
   }
 
   override fun hashCode(): Int {
-    return dpsAlertId.hashCode()
+    return offenderNo.hashCode()
   }
 
   override fun isNew(): Boolean = new
 
-  override fun getId(): String = dpsAlertId
-}
-
-enum class AlertMappingType {
-  MIGRATED,
-  DPS_CREATED,
-  NOMIS_CREATED,
+  override fun getId(): String = offenderNo
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertPrisonerMappingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertPrisonerMappingRepository.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.alerts
+
+import kotlinx.coroutines.flow.Flow
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AlertPrisonerMappingRepository : CoroutineCrudRepository<AlertPrisonerMapping, String> {
+  suspend fun findAllByLabelAndMappingTypeOrderByLabelDesc(label: String, mappingType: AlertMappingType, pageRequest: Pageable): Flow<AlertPrisonerMapping>
+
+  suspend fun countAllByLabelAndMappingType(migrationId: String, mappingType: AlertMappingType): Long
+}

--- a/src/main/resources/db/migration/V1_42__alert_prisoner_number.sql
+++ b/src/main/resources/db/migration/V1_42__alert_prisoner_number.sql
@@ -1,0 +1,14 @@
+alter table alert_mapping
+    add column offender_no varchar(10);
+
+create index alert_mapping_offender_no on alert_mapping (offender_no);
+
+create table alert_prisoner_mapping
+(
+    offender_no  varchar(10)              not null PRIMARY KEY,
+    count        bigint                   not null,
+    when_created timestamp with time zone not null default now(),
+    label        varchar(20),
+    mapping_type varchar(20)              not null
+);
+create index alert_prisoner_mapping_label_index on alert_prisoner_mapping (label);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingResourceIntTest.kt
@@ -26,6 +26,9 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
   @Autowired
   private lateinit var repository: AlertsMappingRepository
 
+  @Autowired
+  private lateinit var alertPrisonerRepository: AlertPrisonerMappingRepository
+
   @Nested
   @DisplayName("GET /mapping/alerts/nomis-booking-id/{bookingId}/nomis-alert-sequence/{alertSequence}")
   inner class GetMappingByNomisId {
@@ -38,6 +41,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
           dpsAlertId = "edcd118c-41ba-42ea-b5c4-404b453ad58b",
           nomisBookingId = 54321L,
           nomisAlertSequence = 2L,
+          offenderNo = "A1234KT",
           label = "2023-01-01T12:45:12",
           mappingType = MIGRATED,
         ),
@@ -46,6 +50,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
 
     @AfterEach
     fun tearDown() = runTest {
+      alertPrisonerRepository.deleteAll()
       repository.deleteAll()
     }
 
@@ -101,6 +106,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
           .jsonPath("nomisAlertSequence").isEqualTo(mapping.nomisAlertSequence)
           .jsonPath("dpsAlertId").isEqualTo(mapping.dpsAlertId)
           .jsonPath("mappingType").isEqualTo(mapping.mappingType.name)
+          .jsonPath("offenderNo").isEqualTo(mapping.offenderNo!!)
           .jsonPath("label").isEqualTo(mapping.label!!)
           .jsonPath("whenCreated").value<String> {
             assertThat(LocalDateTime.parse(it)).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS))
@@ -121,6 +127,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
           dpsAlertId = "edcd118c-41ba-42ea-b5c4-404b453ad58b",
           nomisBookingId = 54321L,
           nomisAlertSequence = 2L,
+          offenderNo = null,
           label = "2023-01-01T12:45:12",
           mappingType = MIGRATED,
         ),
@@ -129,6 +136,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
 
     @AfterEach
     fun tearDown() = runTest {
+      alertPrisonerRepository.deleteAll()
       repository.deleteAll()
     }
 
@@ -183,6 +191,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
           .jsonPath("nomisBookingId").isEqualTo(mapping.nomisBookingId)
           .jsonPath("nomisAlertSequence").isEqualTo(mapping.nomisAlertSequence)
           .jsonPath("dpsAlertId").isEqualTo(mapping.dpsAlertId)
+          .jsonPath("offenderNo").doesNotExist()
           .jsonPath("mappingType").isEqualTo(mapping.mappingType.name)
           .jsonPath("label").isEqualTo(mapping.label!!)
           .jsonPath("whenCreated").value<String> {
@@ -204,6 +213,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
           dpsAlertId = "edcd118c-41ba-42ea-b5c4-404b453ad58b",
           nomisBookingId = 54321L,
           nomisAlertSequence = 2L,
+          offenderNo = "A1234KT",
           label = "2023-01-01T12:45:12",
           mappingType = MIGRATED,
         ),
@@ -212,6 +222,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
 
     @AfterEach
     fun tearDown() = runTest {
+      alertPrisonerRepository.deleteAll()
       repository.deleteAll()
     }
 
@@ -286,6 +297,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
       dpsAlertId = "e52d7268-6e10-41a8-a0b9-2319b32520d6",
       nomisBookingId = 54321L,
       nomisAlertSequence = 3L,
+      offenderNo = "A1234KT",
       label = "2023-01-01T12:45:12",
       mappingType = MIGRATED,
     )
@@ -298,6 +310,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
           nomisBookingId = 54321L,
           nomisAlertSequence = 2L,
           label = "2023-01-01T12:45:12",
+          offenderNo = "A1234KT",
           mappingType = MIGRATED,
         ),
       )
@@ -305,6 +318,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
 
     @AfterEach
     fun tearDown() = runTest {
+      alertPrisonerRepository.deleteAll()
       repository.deleteAll()
     }
 
@@ -537,6 +551,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
                 nomisBookingId = existingMapping.nomisBookingId,
                 nomisAlertSequence = existingMapping.nomisAlertSequence,
                 dpsAlertId = dpsAlertId,
+                offenderNo = existingMapping.offenderNo,
               ),
             ),
           )
@@ -573,6 +588,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
                 nomisBookingId = existingMapping.nomisBookingId,
                 nomisAlertSequence = 99,
                 dpsAlertId = existingMapping.dpsAlertId,
+                offenderNo = existingMapping.offenderNo,
               ),
             ),
           )
@@ -610,6 +626,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
         nomisAlertSequence = 3L,
         label = "2023-01-01T12:45:12",
         mappingType = MIGRATED,
+        offenderNo = "A1234KT",
       ),
       AlertMappingDto(
         dpsAlertId = "fd4e55a8-0805-439b-9e27-647583b96e4e",
@@ -617,6 +634,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
         nomisAlertSequence = 4L,
         label = "2023-01-01T12:45:12",
         mappingType = MIGRATED,
+        offenderNo = "A1234KT",
       ),
     )
 
@@ -629,12 +647,14 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
           nomisAlertSequence = 2L,
           label = "2023-01-01T12:45:12",
           mappingType = MIGRATED,
+          offenderNo = "A1234KT",
         ),
       )
     }
 
     @AfterEach
     fun tearDown() = runTest {
+      alertPrisonerRepository.deleteAll()
       repository.deleteAll()
     }
 
@@ -892,7 +912,47 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
                   nomisBookingId = existingMapping.nomisBookingId,
                   nomisAlertSequence = existingMapping.nomisAlertSequence,
                   dpsAlertId = dpsAlertId,
+                  offenderNo = existingMapping.offenderNo,
                 ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isEqualTo(409)
+          .expectBody(
+            object :
+              ParameterizedTypeReference<TestDuplicateErrorResponse>() {},
+          )
+          .returnResult().responseBody
+
+        with(duplicateResponse!!) {
+          // since this is an untyped map an int will be assumed for such small numbers
+          assertThat(this.moreInfo.existing)
+            .containsEntry("nomisBookingId", existingMapping.nomisBookingId.toInt())
+            .containsEntry("nomisAlertSequence", existingMapping.nomisAlertSequence.toInt())
+            .containsEntry("offenderNo", existingMapping.offenderNo)
+            .containsEntry("dpsAlertId", existingMapping.dpsAlertId)
+          assertThat(this.moreInfo.duplicate)
+            .containsEntry("nomisBookingId", existingMapping.nomisBookingId.toInt())
+            .containsEntry("nomisAlertSequence", existingMapping.nomisAlertSequence.toInt())
+            .containsEntry("offenderNo", existingMapping.offenderNo)
+            .containsEntry("dpsAlertId", dpsAlertId)
+        }
+      }
+
+      @Test
+      fun `returns 409 if dps id already exist`() {
+        val duplicateResponse = webTestClient.post()
+          .uri("/mapping/alerts/all")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              mappings + AlertMappingDto(
+                nomisBookingId = existingMapping.nomisBookingId,
+                nomisAlertSequence = 99,
+                dpsAlertId = existingMapping.dpsAlertId,
+                offenderNo = existingMapping.offenderNo,
+              ),
             ),
           )
           .exchange()
@@ -911,7 +971,269 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
             .containsEntry("dpsAlertId", existingMapping.dpsAlertId)
           assertThat(this.moreInfo.duplicate)
             .containsEntry("nomisBookingId", existingMapping.nomisBookingId.toInt())
+            .containsEntry("nomisAlertSequence", 99)
+            .containsEntry("dpsAlertId", existingMapping.dpsAlertId)
+        }
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("POST /mapping/alerts/{offenderNo}/all")
+  inner class CreateMappingsForPrisoner {
+    private lateinit var existingMapping: AlertMapping
+    private val prisonerMappings = PrisonerAlertMappingsDto(
+      label = "2023-01-01T12:45:12",
+      mappingType = MIGRATED,
+      mappings = listOf(
+        AlertMappingIdDto(
+          dpsAlertId = "e52d7268-6e10-41a8-a0b9-2319b32520d6",
+          nomisBookingId = 54321L,
+          nomisAlertSequence = 3L,
+        ),
+        AlertMappingIdDto(
+          dpsAlertId = "fd4e55a8-0805-439b-9e27-647583b96e4e",
+          nomisBookingId = 54321L,
+          nomisAlertSequence = 4L,
+        ),
+      ),
+    )
+
+    @BeforeEach
+    fun setUp() = runTest {
+      existingMapping = repository.save(
+        AlertMapping(
+          dpsAlertId = "edcd118c-41ba-42ea-b5c4-404b453ad58b",
+          nomisBookingId = 54321L,
+          nomisAlertSequence = 2L,
+          label = "2023-01-01T12:45:12",
+          mappingType = MIGRATED,
+          offenderNo = "A1234KT",
+        ),
+      )
+    }
+
+    @AfterEach
+    fun tearDown() = runTest {
+      alertPrisonerRepository.deleteAll()
+      repository.deleteAll()
+    }
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access not authorised when no authority`() {
+        webTestClient.post()
+          .uri("/mapping/alerts/A1234KT/all")
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(prisonerMappings))
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.post()
+          .uri("/mapping/alerts/A1234KT/all")
+          .headers(setAuthorisation(roles = listOf()))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(prisonerMappings))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.post()
+          .uri("/mapping/alerts/A1234KT/all")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(prisonerMappings))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `returns 201 when mapping created`() = runTest {
+        webTestClient.post()
+          .uri("/mapping/alerts/A1234KT/all")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(prisonerMappings))
+          .exchange()
+          .expectStatus().isCreated
+
+        val createdMapping1 =
+          repository.findOneByNomisBookingIdAndNomisAlertSequence(
+            bookingId = prisonerMappings.mappings[0].nomisBookingId,
+            alertSequence = prisonerMappings.mappings[0].nomisAlertSequence,
+          )!!
+
+        assertThat(createdMapping1.whenCreated).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS))
+        assertThat(createdMapping1.nomisBookingId).isEqualTo(prisonerMappings.mappings[0].nomisBookingId)
+        assertThat(createdMapping1.nomisAlertSequence).isEqualTo(prisonerMappings.mappings[0].nomisAlertSequence)
+        assertThat(createdMapping1.dpsAlertId).isEqualTo(prisonerMappings.mappings[0].dpsAlertId)
+        assertThat(createdMapping1.mappingType).isEqualTo(prisonerMappings.mappingType)
+        assertThat(createdMapping1.label).isEqualTo(prisonerMappings.label)
+        val createdMapping2 =
+          repository.findOneByNomisBookingIdAndNomisAlertSequence(
+            bookingId = prisonerMappings.mappings[1].nomisBookingId,
+            alertSequence = prisonerMappings.mappings[1].nomisAlertSequence,
+          )!!
+
+        assertThat(createdMapping2.whenCreated).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS))
+        assertThat(createdMapping2.nomisBookingId).isEqualTo(prisonerMappings.mappings[1].nomisBookingId)
+        assertThat(createdMapping2.nomisAlertSequence).isEqualTo(prisonerMappings.mappings[1].nomisAlertSequence)
+        assertThat(createdMapping2.dpsAlertId).isEqualTo(prisonerMappings.mappings[1].dpsAlertId)
+        assertThat(createdMapping2.mappingType).isEqualTo(prisonerMappings.mappingType)
+        assertThat(createdMapping2.label).isEqualTo(prisonerMappings.label)
+      }
+    }
+
+    @Nested
+    inner class Validation {
+      @Test
+      fun `returns 400 when mapping type is invalid`() {
+        webTestClient.post()
+          .uri("/mapping/alerts/A1234KT/all")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              //language=JSON
+              """
+                {
+                  "mappingType": "INVALID_TYPE",
+                  "mappings": [
+                    {
+                      "nomisBookingId": 54321,
+                      "nomisAlertSequence": 3,
+                      "dpsAlertId": "e52d7268-6e10-41a8-a0b9-2319b32520d6"
+                    }
+                  ]
+                }
+              """.trimIndent(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isBadRequest
+      }
+
+      @Test
+      fun `returns 400 when DPS id is missing`() {
+        webTestClient.post()
+          .uri("/mapping/alerts/A1234KT/all")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              //language=JSON
+              """
+                {
+                  "mappingType": "MIGRATED",
+                  "mappings": [
+                    {
+                      "nomisBookingId": 54321,
+                      "nomisAlertSequence": 3
+                    }
+                  ]
+                }
+              """.trimIndent(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isBadRequest
+      }
+
+      @Test
+      fun `returns 400 when NOMIS ids are missing`() {
+        webTestClient.post()
+          .uri("/mapping/alerts/A1234KT/all")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              //language=JSON
+              """
+                {
+                  "mappingType": "MIGRATED",
+                  "mappings": [
+                    {
+                      "dpsAlertId": "e52d7268-6e10-41a8-a0b9-2319b32520d6",
+                      "nomisAlertSequence": 3
+                    }
+                  ]
+                }
+              """.trimIndent(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isBadRequest
+
+        webTestClient.post()
+          .uri("/mapping/alerts/A1234KT/all")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              //language=JSON
+              """
+                {
+                  "mappingType": "MIGRATED",
+                  "mappings": [
+                    {
+                      "nomisBookingId": 54321,
+                      "dpsAlertId": "e52d7268-6e10-41a8-a0b9-2319b32520d6"
+                    }
+                  ]
+                }
+              """.trimIndent(),
+            ),
+          )
+          .exchange()
+          .expectStatus().isBadRequest
+      }
+
+      @Test
+      fun `returns 409 if nomis ids already exist`() {
+        val dpsAlertId = UUID.randomUUID().toString()
+        val duplicateResponse = webTestClient.post()
+          .uri("/mapping/alerts/A1234KT/all")
+          .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(
+            BodyInserters.fromValue(
+              prisonerMappings.copy(
+                mappings = prisonerMappings.mappings + AlertMappingIdDto(
+                  nomisBookingId = existingMapping.nomisBookingId,
+                  nomisAlertSequence = existingMapping.nomisAlertSequence,
+                  dpsAlertId = dpsAlertId,
+                ),
+              ),
+            ),
+          )
+          .exchange()
+          .expectStatus().isEqualTo(409)
+          .expectBody(
+            object :
+              ParameterizedTypeReference<TestDuplicateErrorResponse>() {},
+          )
+          .returnResult().responseBody
+
+        with(duplicateResponse!!) {
+          // since this is an untyped map an int will be assumed for such small numbers
+          assertThat(this.moreInfo.existing)
+            .containsEntry("nomisBookingId", existingMapping.nomisBookingId.toInt())
             .containsEntry("nomisAlertSequence", existingMapping.nomisAlertSequence.toInt())
+            .containsEntry("offenderNo", existingMapping.offenderNo)
+            .containsEntry("dpsAlertId", existingMapping.dpsAlertId)
+          assertThat(this.moreInfo.duplicate)
+            .containsEntry("nomisBookingId", existingMapping.nomisBookingId.toInt())
+            .containsEntry("nomisAlertSequence", existingMapping.nomisAlertSequence.toInt())
+            .containsEntry("offenderNo", existingMapping.offenderNo)
             .containsEntry("dpsAlertId", dpsAlertId)
         }
       }
@@ -919,15 +1241,17 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
       @Test
       fun `returns 409 if dps id already exist`() {
         val duplicateResponse = webTestClient.post()
-          .uri("/mapping/alerts/all")
+          .uri("/mapping/alerts/A1234KT/all")
           .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
           .contentType(MediaType.APPLICATION_JSON)
           .body(
             BodyInserters.fromValue(
-              mappings + AlertMappingDto(
-                nomisBookingId = existingMapping.nomisBookingId,
-                nomisAlertSequence = 99,
-                dpsAlertId = existingMapping.dpsAlertId,
+              prisonerMappings.copy(
+                mappings = prisonerMappings.mappings + AlertMappingIdDto(
+                  nomisBookingId = existingMapping.nomisBookingId,
+                  nomisAlertSequence = 99,
+                  dpsAlertId = existingMapping.dpsAlertId,
+                ),
               ),
             ),
           )
@@ -969,6 +1293,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
           nomisAlertSequence = 2L,
           label = "2023-01-01T12:45:12",
           mappingType = MIGRATED,
+          offenderNo = "A1234KT",
         ),
       )
       existingMapping2 = repository.save(
@@ -977,12 +1302,14 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
           nomisBookingId = 54321L,
           nomisAlertSequence = 3L,
           mappingType = NOMIS_CREATED,
+          offenderNo = "A1234KT",
         ),
       )
     }
 
     @AfterEach
     fun tearDown() = runTest {
+      alertPrisonerRepository.deleteAll()
       repository.deleteAll()
     }
 
@@ -1060,6 +1387,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
 
     @AfterEach
     internal fun deleteData() = runBlocking {
+      alertPrisonerRepository.deleteAll()
       repository.deleteAll()
     }
 
@@ -1099,6 +1427,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
             nomisAlertSequence = it,
             label = "2023-01-01T12:45:12",
             mappingType = MIGRATED,
+            offenderNo = "A1234KT",
           ),
         )
       }
@@ -1110,6 +1439,7 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
           nomisAlertSequence = 99,
           label = "2022-01-01T12:43:12",
           mappingType = MIGRATED,
+          offenderNo = "A1234KT",
         ),
       )
 
@@ -1151,6 +1481,259 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
             nomisAlertSequence = it,
             label = "2023-01-01T12:45:12",
             mappingType = MIGRATED,
+            offenderNo = "A1234KT",
+          ),
+        )
+      }
+      webTestClient.get().uri {
+        it.path("/mapping/alerts/migration-id/2023-01-01T12:45:12")
+          .queryParam("size", "2")
+          .queryParam("sort", "nomisAlertSequence,asc")
+          .build()
+      }
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("totalElements").isEqualTo(6)
+        .jsonPath("numberOfElements").isEqualTo(2)
+        .jsonPath("number").isEqualTo(0)
+        .jsonPath("totalPages").isEqualTo(3)
+        .jsonPath("size").isEqualTo(2)
+    }
+  }
+
+  @DisplayName("GET /mapping/alerts/migration-id/{migrationId}/grouped-by-prisoner")
+  @Nested
+  inner class GetMappingByMigrationIdGroupedByPrisoner {
+
+    @AfterEach
+    internal fun deleteData() = runBlocking {
+      alertPrisonerRepository.deleteAll()
+      repository.deleteAll()
+    }
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access not authorised when no authority`() {
+        webTestClient.get().uri("/mapping/alerts/migration-id/2022-01-01T00:00:00/grouped-by-prisoner")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.get().uri("/mapping/alerts/migration-id/2022-01-01T00:00:00/grouped-by-prisoner")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.get().uri("/mapping/alerts/migration-id/2022-01-01T00:00:00/grouped-by-prisoner")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    @Test
+    fun `can retrieve all mappings by migration Id when created via the 'all' endpoint`() = runTest {
+      webTestClient.post()
+        .uri("/mapping/alerts/all")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            (1L..4L).map {
+              AlertMappingDto(
+                dpsAlertId = "edcd118c-${it}1ba-42ea-b5c4-404b453ad58b",
+                nomisBookingId = 54321L,
+                nomisAlertSequence = it,
+                label = "2023-01-01T12:45:12",
+                mappingType = MIGRATED,
+                offenderNo = "A1111KT",
+              )
+            },
+          ),
+        )
+        .exchange()
+        .expectStatus().isCreated
+
+      webTestClient.post()
+        .uri("/mapping/alerts/all")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            (5L..6L).map {
+              AlertMappingDto(
+                dpsAlertId = "edcd118c-${it}1ba-42ea-b5c4-404b453ad58b",
+                nomisBookingId = 54321L,
+                nomisAlertSequence = it,
+                label = "2023-01-01T12:45:12",
+                mappingType = MIGRATED,
+                offenderNo = "A2222KT",
+              )
+            },
+          ),
+        )
+        .exchange()
+        .expectStatus().isCreated
+
+      webTestClient.post()
+        .uri("/mapping/alerts/all")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            listOf(
+              AlertMappingDto(
+                dpsAlertId = "edcd118c-91ba-42ea-b5c4-404b453ad58b",
+                nomisBookingId = 54321L,
+                nomisAlertSequence = 99,
+                label = "2022-01-01T12:43:12",
+                mappingType = MIGRATED,
+                offenderNo = "A1234KT",
+              ),
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isCreated
+
+      webTestClient.get().uri("/mapping/alerts/migration-id/2023-01-01T12:45:12/grouped-by-prisoner")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("totalElements").isEqualTo(2)
+        .jsonPath("$.content..offenderNo").value(
+          Matchers.contains(
+            "A1111KT",
+            "A2222KT",
+          ),
+        )
+        .jsonPath("$.content..mappingsCount").value(
+          Matchers.contains(
+            4,
+            2,
+          ),
+        )
+    }
+
+    @Test
+    fun `can retrieve all mappings by migration Id when created via the 'offenderNo all' endpoint`() = runTest {
+      webTestClient.post()
+        .uri("/mapping/alerts/A1111KT/all")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            PrisonerAlertMappingsDto(
+              label = "2023-01-01T12:45:12",
+              mappingType = MIGRATED,
+              mappings = (1L..4L).map {
+                AlertMappingIdDto(
+                  dpsAlertId = "edcd118c-${it}1ba-42ea-b5c4-404b453ad58b",
+                  nomisBookingId = 54321L,
+                  nomisAlertSequence = it,
+                )
+              },
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isCreated
+
+      webTestClient.post()
+        .uri("/mapping/alerts/A2222KT/all")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            PrisonerAlertMappingsDto(
+              label = "2023-01-01T12:45:12",
+              mappingType = MIGRATED,
+              mappings = (5L..6L).map {
+                AlertMappingIdDto(
+                  dpsAlertId = "edcd118c-${it}1ba-42ea-b5c4-404b453ad58b",
+                  nomisBookingId = 54321L,
+                  nomisAlertSequence = it,
+                )
+              },
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isCreated
+
+      webTestClient.post()
+        .uri("/mapping/alerts/A1234KT/all")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+          BodyInserters.fromValue(
+            PrisonerAlertMappingsDto(
+              label = "2022-01-01T12:43:12",
+              mappingType = MIGRATED,
+              mappings = listOf(
+                AlertMappingIdDto(
+                  dpsAlertId = "edcd118c-91ba-42ea-b5c4-404b453ad58b",
+                  nomisBookingId = 54321L,
+                  nomisAlertSequence = 99,
+                ),
+              ),
+            ),
+          ),
+        )
+        .exchange()
+        .expectStatus().isCreated
+
+      webTestClient.get().uri("/mapping/alerts/migration-id/2023-01-01T12:45:12/grouped-by-prisoner")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("totalElements").isEqualTo(2)
+        .jsonPath("$.content..offenderNo").value(
+          Matchers.contains(
+            "A1111KT",
+            "A2222KT",
+          ),
+        )
+        .jsonPath("$.content..mappingsCount").value(
+          Matchers.contains(
+            4,
+            2,
+          ),
+        )
+    }
+
+    @Test
+    fun `200 response even when no mappings are found`() {
+      webTestClient.get().uri("/mapping/alerts/migration-id/2044-01-01")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("totalElements").isEqualTo(0)
+        .jsonPath("content").isEmpty
+    }
+
+    @Test
+    fun `can request a different page size`() = runTest {
+      (1L..6L).forEach {
+        repository.save(
+          AlertMapping(
+            dpsAlertId = "edcd118c-${it}1ba-42ea-b5c4-404b453ad58b",
+            nomisBookingId = 54321L,
+            nomisAlertSequence = it,
+            label = "2023-01-01T12:45:12",
+            mappingType = MIGRATED,
+            offenderNo = "A1234KT",
           ),
         )
       }


### PR DESCRIPTION
This adds two new endpoints:
* Create alerts by prisoner number, the old version will be deleted when all environments use the new version
* Get a summary of prisoners migrated

This added offenderNo to the alert mapping table as a convenience column and also adds a new table that is just a list of prisoners migrated.

This all differs from usual pattern because we migrate a batch of alerts by prisoner, so we need to know both how many prisoners have been migrated and how many alerts have been migrated.