### PR TITLE
SDIT-1658 Return whenCreated in alerts grouped-by-prisoner

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingDto.kt
@@ -38,6 +38,9 @@ data class PrisonerAlertMappingsSummaryDto(
 
   @Schema(description = "Count of the number mappings migrated (does not include subsequent alerts synchronised")
   val mappingsCount: Int,
+
+  @Schema(description = "Date time the mapping was created")
+  val whenCreated: LocalDateTime?,
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingService.kt
@@ -112,7 +112,14 @@ class AlertMappingService(
     }
 
     PageImpl(
-      mappings.await().toList().map { PrisonerAlertMappingsSummaryDto(it.offenderNo, it.count) },
+      mappings.await().toList()
+        .map {
+          PrisonerAlertMappingsSummaryDto(
+            offenderNo = it.offenderNo,
+            mappingsCount = it.count,
+            whenCreated = it.whenCreated,
+          )
+        },
       pageRequest,
       count.await(),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/alerts/AlertMappingResourceIntTest.kt
@@ -1226,6 +1226,20 @@ class AlertMappingResourceIntTest : IntegrationTestBase() {
             2,
           ),
         )
+      webTestClient.get().uri("/mapping/alerts/migration-id/2023-01-01T12:45:12/grouped-by-prisoner?size=1")
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ALERTS")))
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("totalElements").isEqualTo(2)
+        .jsonPath("numberOfElements").isEqualTo(1)
+        .jsonPath("$.content[0].offenderNo").isEqualTo("A1111KT")
+        .jsonPath("$.content[0].whenCreated").value<String> {
+          assertThat(LocalDateTime.parse(it)).isCloseTo(
+            LocalDateTime.now(),
+            within(10, ChronoUnit.MINUTES),
+          )
+        }
     }
 
     @Test


### PR DESCRIPTION
whenCreated  is required to work out how many alerts have been migrated