### PR TITLE
SDIT-1789 Add method to fetch punishment mapping by NOMIS booking id …

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/jpa/repository/AdjudicationPunishmentMappingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/jpa/repository/AdjudicationPunishmentMappingRepository.kt
@@ -10,4 +10,5 @@ interface AdjudicationPunishmentMappingRepository : CoroutineCrudRepository<Adju
   suspend fun deleteByLabel(label: String)
   suspend fun deleteAllByMappingType(adjudicationMappingType: AdjudicationMappingType)
   suspend fun deleteByNomisBookingIdAndNomisSanctionSequence(nomisBookingId: Long, nomisSanctionSequence: Int)
+  suspend fun findByNomisBookingIdAndNomisSanctionSequence(nomisBookingId: Long, nomisSanctionSequence: Int): AdjudicationPunishmentMapping?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/resource/PunishmentsMappingResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/resource/PunishmentsMappingResource.kt
@@ -144,6 +144,40 @@ class PunishmentsMappingResource(private val mappingService: AdjudicationMapping
   ): AdjudicationPunishmentMappingDto = mappingService.getPunishmentMappingByDpsId(dpsPunishmentId)
 
   @PreAuthorize("hasRole('ROLE_NOMIS_ADJUDICATIONS')")
+  @GetMapping("/mapping/punishments/nomis-booking-id/{nomisBookingId}/nomis-sanction-sequence/{nomisSanctionSequence}")
+  @Operation(
+    summary = "get mapping",
+    description = "Retrieves a mapping by NOMIS booking id and sanction sequence. Requires role NOMIS_ADJUDICATIONS",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Mapping Information Returned",
+        content = [
+          Content(mediaType = "application/json", schema = Schema(implementation = AdjudicationPunishmentMappingDto::class)),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Id does not exist in mapping table",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  suspend fun getMappingGivenNomisId(
+    @Schema(description = "NOMIS Booking Id", example = "12345", required = true)
+    @PathVariable
+    nomisBookingId: Long,
+    @Schema(description = "NOMIS sanction sequence", example = "12", required = true)
+    @PathVariable
+    nomisSanctionSequence: Int,
+  ): AdjudicationPunishmentMappingDto = mappingService.getPunishmentMappingByNomisId(nomisBookingId, nomisSanctionSequence)
+
+  @PreAuthorize("hasRole('ROLE_NOMIS_ADJUDICATIONS')")
   @DeleteMapping("/mapping/punishments/{dpsPunishmentId}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/service/AdjudicationMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/service/AdjudicationMappingService.kt
@@ -271,6 +271,11 @@ class AdjudicationMappingService(
       ?.let { AdjudicationPunishmentMappingDto(it) }
       ?: throw NotFoundException("DPS punishment Id=$dpsPunishmentId")
 
+  suspend fun getPunishmentMappingByNomisId(bookingId: Long, sanctionSequence: Int): AdjudicationPunishmentMappingDto =
+    adjudicationPunishmentMappingRepository.findByNomisBookingIdAndNomisSanctionSequence(nomisBookingId = bookingId, nomisSanctionSequence = sanctionSequence)
+      ?.let { AdjudicationPunishmentMappingDto(it) }
+      ?: throw NotFoundException("NOMIS booking Id=$bookingId, sanction sequence=$sanctionSequence")
+
   @Transactional
   suspend fun deletePunishmentMappingByDpsId(dpsPunishmentId: String) =
     adjudicationPunishmentMappingRepository.deleteById(dpsPunishmentId)


### PR DESCRIPTION
…and sanction sequence

A new method has been introduced in the AdjudicationMappingService to allow fetching punishment mapping records based on NOMIS booking Ids and sanction sequences.