### PR TITLE
SDIT-2090 Contact phones can now have a DPS type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/AbstractContactPersonMapping.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/AbstractContactPersonMapping.kt
@@ -5,7 +5,7 @@ import org.springframework.data.annotation.Transient
 import org.springframework.data.domain.Persistable
 import java.time.LocalDateTime
 
-abstract class AbstractContactPersonMapping(
+abstract class AbstractContactPersonMappingTyped<T>(
   val label: String? = null,
   val mappingType: ContactPersonMappingType,
 
@@ -15,7 +15,9 @@ abstract class AbstractContactPersonMapping(
 
   val whenCreated: LocalDateTime? = null,
 
-) : Persistable<String> {
+) : Persistable<T> {
 
   override fun isNew(): Boolean = new
 }
+
+typealias AbstractContactPersonMapping = AbstractContactPersonMappingTyped<String>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/ContactPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/ContactPersonService.kt
@@ -165,3 +165,12 @@ private inline fun <reified T : AbstractContactPersonMapping> ContactPersonMappi
     this.mappingType,
     this.whenCreated,
   )
+
+private fun ContactPersonMappingsDto.toMapping(mapping: ContactPersonPhoneMappingIdDto) = PersonPhoneMapping(
+  nomisId = mapping.nomisId,
+  dpsId = mapping.dpsId,
+  dpsPhoneType = mapping.dpsPhoneType,
+  label = label,
+  mappingType = mappingType,
+  whenCreated = whenCreated,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/PersonContactMappingDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/PersonContactMappingDto.kt
@@ -18,7 +18,7 @@ data class ContactPersonMappingsDto(
   @Schema(description = "Person address mapping")
   val personAddressMapping: List<ContactPersonSimpleMappingIdDto>,
   @Schema(description = "Person phone mapping")
-  val personPhoneMapping: List<ContactPersonSimpleMappingIdDto>,
+  val personPhoneMapping: List<ContactPersonPhoneMappingIdDto>,
   @Schema(description = "Person email mapping")
   val personEmailMapping: List<ContactPersonSimpleMappingIdDto>,
   @Schema(description = "Person employment mapping")
@@ -40,6 +40,17 @@ data class ContactPersonSimpleMappingIdDto(
   val dpsId: String,
   @Schema(description = "NOMIS id")
   val nomisId: Long,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "NOMIS to DPS simple mapping IDs")
+data class ContactPersonPhoneMappingIdDto(
+  @Schema(description = "NOMIS id")
+  val nomisId: Long,
+  @Schema(description = "DPS id")
+  val dpsId: String,
+  @Schema(description = "DPS phone type", allowableValues = ["ADDRESS", "PERSON"])
+  val dpsPhoneType: DpsPersonPhoneType,
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/PersonPhoneMapping.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/PersonPhoneMapping.kt
@@ -5,20 +5,26 @@ import java.time.LocalDateTime
 
 class PersonPhoneMapping(
   @Id
-  val dpsId: String,
   val nomisId: Long,
+  val dpsId: String,
+  val dpsPhoneType: DpsPersonPhoneType,
   label: String? = null,
   mappingType: ContactPersonMappingType,
   whenCreated: LocalDateTime? = null,
-) : AbstractContactPersonMapping(label = label, mappingType = mappingType, whenCreated = whenCreated) {
+) : AbstractContactPersonMappingTyped<Long>(label = label, mappingType = mappingType, whenCreated = whenCreated) {
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other !is PersonPhoneMapping) return false
-    if (dpsId != other.dpsId) return false
+    if (nomisId != other.nomisId) return false
     return true
   }
 
-  override fun hashCode(): Int = dpsId.hashCode()
-  override fun getId(): String = dpsId
+  override fun hashCode(): Int = nomisId.hashCode()
+  override fun getId(): Long = nomisId
+}
+
+enum class DpsPersonPhoneType {
+  ADDRESS,
+  PERSON,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/PersonPhoneMappingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/PersonPhoneMappingRepository.kt
@@ -4,7 +4,7 @@ import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface PersonPhoneMappingRepository : CoroutineCrudRepository<PersonPhoneMapping, String> {
+interface PersonPhoneMappingRepository : CoroutineCrudRepository<PersonPhoneMapping, Long> {
   suspend fun findOneByNomisId(nomisId: Long): PersonPhoneMapping?
-  suspend fun findOneByDpsId(dpsId: String): PersonPhoneMapping?
+  suspend fun findOneByDpsIdAndDpsPhoneType(dpsId: String, dpsPhoneType: DpsPersonPhoneType): PersonPhoneMapping?
 }

--- a/src/main/resources/db/migration/V1_77__person_phone.sql
+++ b/src/main/resources/db/migration/V1_77__person_phone.sql
@@ -1,0 +1,14 @@
+drop table person_phone_mapping;
+
+create table person_phone_mapping
+(
+    nomis_id       bigint                   not null PRIMARY KEY,
+    dps_id         varchar(36)              not null,
+    dps_phone_type varchar(20)              not null,
+    when_created   timestamp with time zone not null default now(),
+    label          varchar(20),
+    mapping_type   varchar(20)              not null,
+    constraint person_phone_mapping_dps_id_unique unique (dps_id, dps_phone_type)
+);
+create index person_phone_mapping_when_created_index on person_phone_mapping (when_created);
+create index person_phone_mapping_label_index on person_phone_mapping (label);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/ContactPersonMappingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/ContactPersonMappingResourceIntTest.kt
@@ -327,8 +327,9 @@ class ContactPersonMappingResourceIntTest : IntegrationTestBase() {
             BodyInserters.fromValue(
               mappings.copy(
                 personPhoneMapping = listOf(
-                  ContactPersonSimpleMappingIdDto(dpsId = "0dcdd1cf-6a40-47d9-9c7e-f8c92452f1a6", nomisId = 1),
-                  ContactPersonSimpleMappingIdDto(dpsId = "e96babce-4a24-49d7-8447-b45f8768f6c1", nomisId = 2),
+                  ContactPersonPhoneMappingIdDto(dpsId = "0dcdd1cf-6a40-47d9-9c7e-f8c92452f1a6", dpsPhoneType = DpsPersonPhoneType.PERSON, nomisId = 1),
+                  ContactPersonPhoneMappingIdDto(dpsId = "e96babce-4a24-49d7-8447-b45f8768f6c1", dpsPhoneType = DpsPersonPhoneType.PERSON, nomisId = 2),
+                  ContactPersonPhoneMappingIdDto(dpsId = "e96babce-4a24-49d7-8447-b45f8768f6c1", dpsPhoneType = DpsPersonPhoneType.ADDRESS, nomisId = 3),
                 ),
               ),
             ),
@@ -338,14 +339,24 @@ class ContactPersonMappingResourceIntTest : IntegrationTestBase() {
 
         with(personPhoneMappingRepository.findOneByNomisId(1)!!) {
           assertThat(dpsId).isEqualTo("0dcdd1cf-6a40-47d9-9c7e-f8c92452f1a6")
+          assertThat(dpsPhoneType).isEqualTo(DpsPersonPhoneType.PERSON)
           assertThat(nomisId).isEqualTo(1L)
           assertThat(label).isEqualTo(mappings.label)
           assertThat(mappingType).isEqualTo(mappings.mappingType)
           assertThat(whenCreated).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS))
         }
-        with(personPhoneMappingRepository.findOneByDpsId("e96babce-4a24-49d7-8447-b45f8768f6c1")!!) {
+        with(personPhoneMappingRepository.findOneByDpsIdAndDpsPhoneType("e96babce-4a24-49d7-8447-b45f8768f6c1", DpsPersonPhoneType.PERSON)!!) {
           assertThat(dpsId).isEqualTo("e96babce-4a24-49d7-8447-b45f8768f6c1")
+          assertThat(dpsPhoneType).isEqualTo(DpsPersonPhoneType.PERSON)
           assertThat(nomisId).isEqualTo(2L)
+          assertThat(label).isEqualTo(mappings.label)
+          assertThat(mappingType).isEqualTo(mappings.mappingType)
+          assertThat(whenCreated).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS))
+        }
+        with(personPhoneMappingRepository.findOneByDpsIdAndDpsPhoneType("e96babce-4a24-49d7-8447-b45f8768f6c1", DpsPersonPhoneType.ADDRESS)!!) {
+          assertThat(dpsId).isEqualTo("e96babce-4a24-49d7-8447-b45f8768f6c1")
+          assertThat(dpsPhoneType).isEqualTo(DpsPersonPhoneType.ADDRESS)
+          assertThat(nomisId).isEqualTo(3L)
           assertThat(label).isEqualTo(mappings.label)
           assertThat(mappingType).isEqualTo(mappings.mappingType)
           assertThat(whenCreated).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS))
@@ -913,8 +924,9 @@ class ContactPersonMappingResourceIntTest : IntegrationTestBase() {
           ),
         ),
         personPhoneMapping = listOf(
-          ContactPersonSimpleMappingIdDto(
+          ContactPersonPhoneMappingIdDto(
             dpsId = "c5a02cec-4aa3-4aa7-9871-41e9c9af50f7",
+            dpsPhoneType = DpsPersonPhoneType.PERSON,
             nomisId = 12345L,
           ),
         ),


### PR DESCRIPTION
DPS Phone Ids are unique per type, ADDRESS or PERSON - unlike NOMIS that a globally unique.

This slightly breaks the pattern that all mapping entities have a primary key of DPS key that is a String, so for Phones switch to Nomis Id - which is a Long - to primary key.

Hence, a few changes t0 break out of the generic pattern.