### PR TITLE
SDIT-2617 Replace redundant DELETE adjudication bulk endpoints with A…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/data/AdjudicationDeleteMappingDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/data/AdjudicationDeleteMappingDto.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.data
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import io.swagger.v3.oas.annotations.media.Schema
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "All DPS ids related to mappings that need deleting")
+data class AdjudicationDeleteMappingDto(
+  @Schema(description = "DPS Charge number", required = true, example = "123456/1")
+  val dpsChargeNumber: String,
+  @Schema(description = "List of DPS hearing Ids", required = true)
+  val dpsHearingIds: List<String> = emptyList(),
+  @Schema(description = "List of DPS punishment Ids", required = true)
+  val dpsPunishmentIds: List<String> = emptyList(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/service/AdjudicationMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/service/AdjudicationMappingService.kt
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.config.DuplicateMappingException
 import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.data.AdjudicationAllMappingDto
+import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.data.AdjudicationDeleteMappingDto
 import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.data.AdjudicationHearingMappingDto
 import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.data.AdjudicationMappingDto
 import uk.gov.justice.digital.hmpps.nomisvisitsmappingservice.data.AdjudicationPunishmentBatchUpdateMappingDto
@@ -179,28 +180,10 @@ class AdjudicationMappingService(
   suspend fun deleteMapping(chargeNumber: String) = adjudicationMappingRepository.deleteById(chargeNumber)
 
   @Transactional
-  suspend fun deleteAllMappings(migrationId: String) {
-    adjudicationMappingRepository.deleteByLabel(migrationId)
-    adjudicationHearingMappingRepository.deleteByLabel(migrationId)
-    adjudicationPunishmentMappingRepository.deleteByLabel(migrationId)
-  }
-
-  @Transactional
-  suspend fun deleteAllMappings(migrationOnly: Boolean, synchronisationOnly: Boolean) {
-    if (migrationOnly == synchronisationOnly) { // implies delete everything even for the weird true/true scenario
-      adjudicationMappingRepository.deleteAll()
-      adjudicationHearingMappingRepository.deleteAll()
-      adjudicationPunishmentMappingRepository.deleteAll()
-    } else {
-      val type = if (migrationOnly) {
-        AdjudicationMappingType.MIGRATED
-      } else {
-        AdjudicationMappingType.ADJUDICATION_CREATED
-      }
-      adjudicationMappingRepository.deleteAllByMappingType(type)
-      adjudicationHearingMappingRepository.deleteAllByMappingType(type)
-      adjudicationPunishmentMappingRepository.deleteAllByMappingType(type)
-    }
+  suspend fun deleteMappingsForAdjudication(mappings: AdjudicationDeleteMappingDto) {
+    adjudicationMappingRepository.deleteById(mappings.dpsChargeNumber)
+    mappings.dpsHearingIds.forEach { adjudicationHearingMappingRepository.deleteById(it) }
+    mappings.dpsPunishmentIds.forEach { adjudicationPunishmentMappingRepository.deleteById(it) }
   }
 
   @Transactional


### PR DESCRIPTION
…djudication specific delete endpoint

The bulk endpoints needed for rerunning a migration are no longer needed. Endpoint to selectively delete mapping related to a single adjudication needed for repair endpoint