### PR TITLE
SDIT-2764 batch endpoint to get all sentence mappings by dps id

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/api/PublicApiResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/api/PublicApiResource.kt
@@ -289,7 +289,7 @@ class PublicApiResource(private val locationService: LocationMappingService, pri
       ),
     ],
   )
-  suspend fun getSentenceMappingByNomisIs(
+  fun getSentenceMappingByNomisIs(
     @RequestBody nomisSentenceIds: List<NomisSentenceId>,
   ): Flow<NomisDpsSentenceMapping> = sentenceService.getSentencesByNomisIds(nomisSentenceIds)
     .map {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/courtsentencing/CourtSentencingMappingResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/courtsentencing/CourtSentencingMappingResource.kt
@@ -1130,7 +1130,7 @@ class CourtSentencingMappingResource(private val mappingService: CourtSentencing
       ),
     ],
   )
-  suspend fun getSentenceMappingsByDpsIds(
+  fun getSentenceMappingsByDpsIds(
     @Schema(description = "List of DPS sentence IDs", example = "[\"ce53d679-dec3-4cd2-9bc7-35037c78c4b7\", \"fd246c2e-146b-47a9-9bda-14c279cd1708\"]", required = true)
     @RequestBody
     dpsSentenceIds: List<String>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/courtsentencing/CourtSentencingMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/courtsentencing/CourtSentencingMappingService.kt
@@ -382,14 +382,14 @@ class CourtSentencingMappingService(
   )?.toSentenceAllMappingDto()
     ?: throw NotFoundException("Sentence mapping not found with nomisBookingId =$nomisBookingId, nomisSentenceSeq =$nomisSentenceSeq")
 
-  suspend fun getSentencesByNomisIds(nomisSentenceIds: List<NomisSentenceId>): Flow<SentenceMapping> = nomisSentenceIds.asFlow().mapNotNull {
+  fun getSentencesByNomisIds(nomisSentenceIds: List<NomisSentenceId>): Flow<SentenceMapping> = nomisSentenceIds.asFlow().mapNotNull {
     sentenceMappingRepository.findByNomisBookingIdAndNomisSentenceSequence(
       nomisBookingId = it.nomisBookingId,
       nomisSentenceSeq = it.nomisSentenceSequence,
     )
   }
 
-  suspend fun getSentenceMappingsByDpsIds(dpsSentenceIds: List<String>): Flow<SentenceMappingDto> = dpsSentenceIds.asFlow().mapNotNull { dpsSentenceId ->
+  fun getSentenceMappingsByDpsIds(dpsSentenceIds: List<String>): Flow<SentenceMappingDto> = dpsSentenceIds.asFlow().mapNotNull { dpsSentenceId ->
     sentenceMappingRepository.findById(dpsSentenceId)?.toSentenceAllMappingDto()
   }
 


### PR DESCRIPTION
Removed unnecessary suspend

"No, a function that returns a Flow does not need to be suspend. In fact, it's generally recommended to avoid making a function suspend when it returns a Flow."