### PR TITLE
SDIT-2822 Make replaceMappings idempotent

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/ContactPersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/ContactPersonService.kt
@@ -112,9 +112,15 @@ class ContactPersonService(
       personContactRestrictionMappingRepository.deleteAllById(personContactRestrictionMappingsToRemoveByDpsId)
       personContactMappingRepository.deleteAllById(personContactMappingsToRemoveByDpsId)
       personContactMapping.forEach {
+        // mappings can remain when events get out of order so we need to delete them first just in case
+        // TODO - further investigate when this happens
+        personContactMappingRepository.deleteById(it.dpsId)
+        personContactMappingRepository.deleteByNomisId(it.nomisId)
         personContactMappingRepository.save(toMapping(it))
       }
       personContactRestrictionMapping.forEach {
+        personContactRestrictionMappingRepository.deleteById(it.dpsId)
+        personContactRestrictionMappingRepository.deleteByNomisId(it.nomisId)
         personContactRestrictionMappingRepository.save(toMapping(it))
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/ContactPersonMappingResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/contactperson/ContactPersonMappingResourceIntTest.kt
@@ -689,6 +689,25 @@ class ContactPersonMappingResourceIntTest : IntegrationTestBase() {
             whenCreated = LocalDateTime.parse("2023-01-01T12:45:12"),
           ),
         )
+        // rouge item that previously was not deleted to due to some other failre
+        personContactMappingRepository.save(
+          PersonContactMapping(
+            dpsId = newDpsContactId1,
+            nomisId = 444,
+            label = "2023-01-01T12:45:12",
+            mappingType = ContactPersonMappingType.MIGRATED,
+            whenCreated = LocalDateTime.parse("2023-01-01T12:45:12"),
+          ),
+        )
+        personContactMappingRepository.save(
+          PersonContactMapping(
+            dpsId = "2477292942",
+            nomisId = 22234,
+            label = "2023-01-01T12:45:12",
+            mappingType = ContactPersonMappingType.MIGRATED,
+            whenCreated = LocalDateTime.parse("2023-01-01T12:45:12"),
+          ),
+        )
       }
 
       @Test


### PR DESCRIPTION
Fix live issue that I still don't fully understand where old mappings remain that block new ones being replaced

I think the scenario is when the reset DPS endpoint is called twice, the 2nd time it has lost track for contacts that have been deleted