### PR TITLE
SDIT-3009 Add optional other mapping updates for recalls

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/courtsentencing/CourtAppearanceRecallMappingDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/courtsentencing/CourtAppearanceRecallMappingDto.kt
@@ -51,4 +51,7 @@ data class CourtAppearanceRecallMappingsDto(
     defaultValue = "DPS_CREATED",
   )
   val mappingType: CourtAppearanceRecallMappingType? = null,
+
+  @Schema(description = "Mappings that need updating")
+  val mappingsToUpdate: CourtCaseBatchUpdateMappingDto = CourtCaseBatchUpdateMappingDto(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/courtsentencing/CourtSentencingMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomisvisitsmappingservice/courtsentencing/CourtSentencingMappingService.kt
@@ -474,6 +474,8 @@ class CourtSentencingMappingService(
 
   @Transactional
   suspend fun createCourtAppearanceRecallMapping(createMappingRequest: CourtAppearanceRecallMappingsDto): Unit = with(createMappingRequest) {
+    updateAllMappingsByNomisId(createMappingRequest.mappingsToUpdate)
+
     courtAppearanceRecallMappingRepository.saveAll(this.toCourtAppearanceRecallMappings()).also {
       telemetryClient.trackEvent(
         "court-appearance-recall-mapping-created",


### PR DESCRIPTION
Since a recall can clone the court cases on to a new booking, we also need to update the DPS mappings to point at the new cases if required