### PR TITLE
SDIT-3815 DPS postcode should be 12 long

### DIFF
--- a/src/main/resources/db/migration/V1_137__tap_postcode_size.sql
+++ b/src/main/resources/db/migration/V1_137__tap_postcode_size.sql
@@ -1,0 +1,2 @@
+alter table tap_schedule_mapping alter column dps_postcode type varchar(12);
+alter table tap_movement_mapping alter column dps_postcode type varchar(12);


### PR DESCRIPTION
We previously agreed with DPS that they would limit user input on postcodes to 12 chars - but I forgot to update the column size to match. We've now received a postcode >10 and the mapping failed to save.