### PR TITLE
SDIT-3824 Update recall/appearance mappings on booking clone

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomismappingservice/courtsentencing/CourtAppearanceRecallMappingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomismappingservice/courtsentencing/CourtAppearanceRecallMappingRepository.kt
@@ -7,6 +7,7 @@ import java.time.LocalDateTime
 @Repository
 interface CourtAppearanceRecallMappingRepository : CoroutineCrudRepository<CourtAppearanceRecallMapping, Long> {
   suspend fun findAllByDpsRecallId(dpsRecallId: String): List<CourtAppearanceRecallMapping>
+  suspend fun findByNomisCourtAppearanceId(nomisId: Long): CourtAppearanceRecallMapping?
   suspend fun deleteByNomisCourtAppearanceId(nomisId: Long)
   suspend fun deleteAllByDpsRecallId(dpsRecallId: String)
   suspend fun deleteByWhenCreatedAfter(dateTime: LocalDateTime)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomismappingservice/courtsentencing/CourtSentencingMappingService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomismappingservice/courtsentencing/CourtSentencingMappingService.kt
@@ -98,7 +98,7 @@ class CourtSentencingMappingService(
 
   @Transactional
   suspend fun replaceAndCreateAllMappings(createMappingRequest: CourtCaseBatchMappingDto) {
-    createMappingRequest.courtCases.map { courtCaseMappingRequest ->
+    createMappingRequest.courtCases.forEach { courtCaseMappingRequest ->
       try {
         deleteCourtCaseMappingByNomisId(courtCaseMappingRequest.nomisCourtCaseId)
         deleteCourtCaseMappingByDpsId(courtCaseMappingRequest.dpsCourtCaseId)
@@ -190,7 +190,7 @@ class CourtSentencingMappingService(
 
   @Transactional
   suspend fun updateAllMappingsByNomisId(updateMappingRequest: CourtCaseBatchUpdateMappingDto) {
-    updateMappingRequest.courtCases.map {
+    updateMappingRequest.courtCases.forEach {
       courtCaseMappingRepository.findByNomisCourtCaseId(it.fromNomisId)?.also { mapping ->
         courtCaseMappingRepository.save(mapping.copy(nomisCourtCaseId = it.toNomisId))
       }
@@ -198,6 +198,12 @@ class CourtSentencingMappingService(
     updateMappingRequest.courtAppearances.forEach {
       courtAppearanceMappingRepository.findByNomisCourtAppearanceId(it.fromNomisId)?.also { mapping ->
         courtAppearanceMappingRepository.save(mapping.copy(nomisCourtAppearanceId = it.toNomisId))
+      }
+
+      courtAppearanceRecallMappingRepository.findByNomisCourtAppearanceId(it.fromNomisId)?.also { mapping ->
+        // nomisCourtAppearanceId is PK, so need to delete and re-insert rather than update
+        courtAppearanceRecallMappingRepository.deleteByNomisCourtAppearanceId(mapping.nomisCourtAppearanceId)
+        courtAppearanceRecallMappingRepository.save(mapping.copy(nomisCourtAppearanceId = it.toNomisId, new = true))
       }
     }
     updateMappingRequest.courtCharges.forEach {
@@ -512,11 +518,11 @@ class CourtSentencingMappingService(
   suspend fun createCourtAppearanceRecallMapping(createMappingRequest: CourtAppearanceRecallMappingsDto): Unit = with(createMappingRequest) {
     updateAllMappingsByNomisId(createMappingRequest.mappingsToUpdate)
 
-    courtAppearanceRecallMappingRepository.saveAll(this.toCourtAppearanceRecallMappings()).also {
+    courtAppearanceRecallMappingRepository.saveAll(this.toCourtAppearanceRecallMappings()).also { appearances ->
       telemetryClient.trackEvent(
         "court-appearance-recall-mapping-created",
         mapOf(
-          "nomisCourtAppearanceId" to it.toList().map { it.nomisCourtAppearanceId }.joinToString(","),
+          "nomisCourtAppearanceId" to appearances.toList().map { it.nomisCourtAppearanceId }.joinToString(","),
           "dpsRecallId" to dpsRecallId,
           "mappingType" to mappingType.toString(),
         ),
@@ -528,11 +534,11 @@ class CourtSentencingMappingService(
   @Transactional
   suspend fun replaceCourtAppearanceRecallMapping(dpsRecallId: String, updateMappingRequest: CourtAppearanceRecallMappingsUpdateDto) {
     courtAppearanceRecallMappingRepository.deleteAllByDpsRecallId(dpsRecallId)
-    courtAppearanceRecallMappingRepository.saveAll(updateMappingRequest.toCourtAppearanceRecallMappings(dpsRecallId)).also {
+    courtAppearanceRecallMappingRepository.saveAll(updateMappingRequest.toCourtAppearanceRecallMappings(dpsRecallId)).also { appearances ->
       telemetryClient.trackEvent(
         "court-appearance-recall-mapping-replaced",
         mapOf(
-          "nomisCourtAppearanceId" to it.toList().map { it.nomisCourtAppearanceId }.joinToString(","),
+          "nomisCourtAppearanceId" to appearances.toList().map { it.nomisCourtAppearanceId }.joinToString(","),
           "dpsRecallId" to dpsRecallId,
         ),
         null,
@@ -543,12 +549,7 @@ class CourtSentencingMappingService(
   @Transactional
   suspend fun deleteCourtAppearanceRecallMappingByDpsId(dpsRecallId: String) = courtAppearanceRecallMappingRepository.deleteAllByDpsRecallId(dpsRecallId)
 
-  @Transactional
-  suspend fun deleteCourtAppearanceRecallMappingByNomisId(courtAppearanceId: Long) = courtAppearanceRecallMappingRepository.deleteByNomisCourtAppearanceId(courtAppearanceId)
-
   suspend fun getCourtAppearanceRecallMappingsByDpsId(dpsRecallId: String): List<CourtAppearanceRecallMappingDto> = courtAppearanceRecallMappingRepository.findAllByDpsRecallId(dpsRecallId).map { it.toCourtAppearanceRecallMappingDto() }
-  suspend fun getCourtAppearanceRecallMappingByNomisId(courtAppearanceId: Long): CourtAppearanceRecallMappingDto = courtAppearanceRecallMappingRepository.findById(courtAppearanceId)?.toCourtAppearanceRecallMappingDto()
-    ?: throw NotFoundException("Nomis Court appearance Id =$courtAppearanceId")
 
   @Transactional
   suspend fun deleteAllMappings() {
@@ -684,12 +685,6 @@ fun CourtAppearanceRecallMapping.toCourtAppearanceRecallMappingDto(): CourtAppea
   whenCreated = this.whenCreated,
 )
 
-fun CourtAppearanceRecallMappingDto.toCourtAppearanceRecallMapping(): CourtAppearanceRecallMapping = CourtAppearanceRecallMapping(
-  nomisCourtAppearanceId = this.nomisCourtAppearanceId,
-  dpsRecallId = this.dpsRecallId,
-  label = this.label,
-  mappingType = mappingType ?: CourtAppearanceRecallMappingType.DPS_CREATED,
-)
 fun CourtAppearanceRecallMappingsDto.toCourtAppearanceRecallMappings(): List<CourtAppearanceRecallMapping> = this.nomisCourtAppearanceIds.map {
   CourtAppearanceRecallMapping(
     nomisCourtAppearanceId = it,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomismappingservice/courtsentencing/CourtSentencingCourtAppearanceResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomismappingservice/courtsentencing/CourtSentencingCourtAppearanceResourceIntTest.kt
@@ -562,7 +562,7 @@ class CourtSentencingCourtAppearanceResourceIntTest : IntegrationTestBase() {
           .returnResult().responseBody
 
         with(duplicateResponse!!) {
-          // since this is an untyped map an int will be assumed for such small numbers
+          // since this is an untyped map, an int will be assumed for such small numbers
           assertThat(this.moreInfo.existing)
             .containsEntry("nomisCourtAppearanceId", existingMapping.nomisCourtAppearanceId.toInt())
             .containsEntry("dpsCourtAppearanceId", existingMapping.dpsCourtAppearanceId)
@@ -595,7 +595,7 @@ class CourtSentencingCourtAppearanceResourceIntTest : IntegrationTestBase() {
           .returnResult().responseBody
 
         with(duplicateResponse!!) {
-          // since this is an untyped map an int will be assumed for such small numbers
+          // since this is an untyped map, an int will be assumed for such small numbers
           assertThat(this.moreInfo.existing)
             .containsEntry("nomisCourtAppearanceId", existingMapping.nomisCourtAppearanceId.toInt())
             .containsEntry("dpsCourtAppearanceId", existingMapping.dpsCourtAppearanceId)
@@ -1001,6 +1001,10 @@ class CourtSentencingCourtAppearanceResourceIntTest : IntegrationTestBase() {
     val fromNomisId = 99L
     val toNomisId = 100L
     val dpsId = UUID.randomUUID().toString()
+    val oldDpsBreachHearingId = UUID.randomUUID().toString()
+    val oldDpsRecallId = UUID.randomUUID().toString()
+    val oldFromBreachHearingNomisId = 97L
+    val oldToBreachHearingNomisId = 98L
 
     private val mapping = CourtAppearanceRecallMappingsDto(
       nomisCourtAppearanceIds = listOf(NOMIS_COURT_APPEARANCE_ID, NOMIS_COURT_APPEARANCE_2_ID),
@@ -1009,7 +1013,7 @@ class CourtSentencingCourtAppearanceResourceIntTest : IntegrationTestBase() {
       mappingType = CourtAppearanceRecallMappingType.DPS_CREATED,
       mappingsToUpdate = CourtCaseBatchUpdateMappingDto(
         courtCases = listOf(SimpleCourtSentencingIdPair(fromNomisId, toNomisId)),
-        courtAppearances = listOf(SimpleCourtSentencingIdPair(fromNomisId, toNomisId)),
+        courtAppearances = listOf(SimpleCourtSentencingIdPair(fromNomisId, toNomisId), SimpleCourtSentencingIdPair(oldFromBreachHearingNomisId, oldToBreachHearingNomisId)),
       ),
     )
 
@@ -1027,6 +1031,21 @@ class CourtSentencingCourtAppearanceResourceIntTest : IntegrationTestBase() {
           nomisCourtAppearanceId = fromNomisId,
           dpsCourtAppearanceId = dpsId,
           mappingType = CourtAppearanceMappingType.NOMIS_CREATED,
+        ),
+      )
+      repository.save(
+        CourtAppearanceMapping(
+          nomisCourtAppearanceId = oldFromBreachHearingNomisId,
+          dpsCourtAppearanceId = oldDpsBreachHearingId,
+          mappingType = CourtAppearanceMappingType.DPS_CREATED,
+        ),
+      )
+
+      courtAppearanceRecallRepository.save(
+        CourtAppearanceRecallMapping(
+          nomisCourtAppearanceId = oldFromBreachHearingNomisId,
+          dpsRecallId = oldDpsRecallId,
+          mappingType = CourtAppearanceRecallMappingType.DPS_CREATED,
         ),
       )
     }
@@ -1104,7 +1123,9 @@ class CourtSentencingCourtAppearanceResourceIntTest : IntegrationTestBase() {
       @Test
       fun `will also update any of the other supplied mappings`() = runTest {
         assertThat(repository.findById(dpsId)?.nomisCourtAppearanceId).isEqualTo(fromNomisId)
+        assertThat(repository.findById(oldDpsBreachHearingId)?.nomisCourtAppearanceId).isEqualTo(oldFromBreachHearingNomisId)
         assertThat(courtCaseMappingRepository.findById(dpsId)?.nomisCourtCaseId).isEqualTo(fromNomisId)
+        assertThat(courtAppearanceRecallRepository.findAllByDpsRecallId(oldDpsRecallId).first().nomisCourtAppearanceId).isEqualTo(oldFromBreachHearingNomisId)
 
         webTestClient.post()
           .uri("/mapping/court-sentencing/court-appearances/recall")
@@ -1115,7 +1136,9 @@ class CourtSentencingCourtAppearanceResourceIntTest : IntegrationTestBase() {
           .expectStatus().isCreated
 
         assertThat(repository.findById(dpsId)?.nomisCourtAppearanceId).isEqualTo(toNomisId)
+        assertThat(repository.findById(oldDpsBreachHearingId)?.nomisCourtAppearanceId).isEqualTo(oldToBreachHearingNomisId)
         assertThat(courtCaseMappingRepository.findById(dpsId)?.nomisCourtCaseId).isEqualTo(toNomisId)
+        assertThat(courtAppearanceRecallRepository.findAllByDpsRecallId(oldDpsRecallId).first().nomisCourtAppearanceId).isEqualTo(oldToBreachHearingNomisId)
       }
 
       @Test


### PR DESCRIPTION
When a court case is copied to latest booking the mappings are updated so the DPS entities are pointing at the new NOMIS entities on the new booking.

The recall to breach hearing (aka court appearance) mappings  were not being updated, which was a bug.