### PR TITLE
SDIT-3845 Endpoint to upsert a court schedule mapping

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomismappingservice/movements/court/schedule/CourtScheduleMappingDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomismappingservice/movements/court/schedule/CourtScheduleMappingDto.kt
@@ -18,3 +18,14 @@ data class CourtScheduleMappingDto(
   @Schema(description = "The source of the mapping", example = "NOMIS_CREATED")
   val mappingType: CourtMappingType,
 )
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Mapping for a single court schedule")
+data class CourtScheduleMappingUpsertByDpsIdResponse(
+  @Schema(description = "The NOMIS event id that was replaced by the upserted event")
+  val replacedNomisEventId: Long? = null,
+) {
+  companion object {
+    val EVENT_ID_NOT_REPLACED = CourtScheduleMappingUpsertByDpsIdResponse()
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomismappingservice/movements/court/schedule/CourtScheduleResource.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomismappingservice/movements/court/schedule/CourtScheduleResource.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -68,6 +69,51 @@ class CourtScheduleResource(
       existing = existing,
       cause = dke,
     )
+  }
+
+  @PutMapping("/dps-id")
+  @Operation(
+    summary = "Creates a court schedule mapping, or updates existing mapping if DPS ID already exists",
+    description = "Creates or updates a schedule mapping. If we find a mapping already exists for the DPS ID requested then we just update the NOMIS ID on that record. However if we find a duplicate for the NOMIS ID requested we reject the request as with the create endpoint. Requires ROLE_NOMIS_MAPPING_API__SYNCHRONISATION__RW",
+    requestBody = io.swagger.v3.oas.annotations.parameters.RequestBody(
+      content = [Content(mediaType = "application/json", schema = Schema(implementation = CourtScheduleMappingDto::class))],
+    ),
+    responses = [
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Access forbidden for this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "409",
+        description = "The mapping already exists.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  suspend fun createOrUpdateCourtScheduleMappingByDpsId(
+    @RequestBody mapping: CourtScheduleMappingDto,
+  ) = try {
+    service.createScheduleMapping(mapping)
+    CourtScheduleMappingUpsertByDpsIdResponse.EVENT_ID_NOT_REPLACED
+  } catch (dke: DuplicateKeyException) {
+    val existing = getExistingCourtScheduleMappingSimilarTo(mapping)
+    if (existing.dpsCourtAppearanceId == mapping.dpsCourtAppearanceId) {
+      service.updateNomisEventId(mapping.dpsCourtAppearanceId, mapping.nomisEventId)
+      CourtScheduleMappingUpsertByDpsIdResponse(replacedNomisEventId = existing.nomisEventId)
+    } else {
+      throw DuplicateMappingException(
+        messageIn = "Court schedule mapping already exists",
+        duplicate = mapping,
+        existing = existing,
+        cause = dke,
+      )
+    }
   }
 
   private suspend fun getExistingCourtScheduleMappingSimilarTo(mapping: CourtScheduleMappingDto) = runCatching {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/nomismappingservice/movements/court/schedule/CourtScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/nomismappingservice/movements/court/schedule/CourtScheduleService.kt
@@ -15,6 +15,14 @@ class CourtScheduleService(
     scheduleRepository.save(mappingDto.toMapping())
   }
 
+  @Transactional
+  suspend fun updateNomisEventId(dpsCourtAppearanceId: UUID, newNomisEventId: Long) {
+    val savedMapping = scheduleRepository.findByDpsCourtAppearanceId(dpsCourtAppearanceId)!!
+    val newMapping = savedMapping.copy(nomisEventId = newNomisEventId)
+    scheduleRepository.save(newMapping)
+    scheduleRepository.delete(savedMapping)
+  }
+
   suspend fun getScheduleMappingByNomisId(nomisEventId: Long) = scheduleRepository.findByNomisEventId(nomisEventId)
     ?.toMappingDto()
     ?: throw NotFoundException("Mapping for NOMIS event id $nomisEventId not found")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/nomismappingservice/movements/court/schedule/CourtScheduleResourceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/nomismappingservice/movements/court/schedule/CourtScheduleResourceIntTest.kt
@@ -178,9 +178,156 @@ class CourtScheduleResourceIntTest(
           .expectStatus().isForbidden
       }
     }
+  }
 
-    private fun WebTestClient.createCourtScheduleMapping(mapping: CourtScheduleMappingDto) = post()
-      .uri("/mapping/court-scheduler/schedule")
+  @Nested
+  @DisplayName("PUT /mapping/court-scheduler/schedule/dps-id")
+  inner class UpsertCourtScheduleMappingByDpsId {
+
+    @AfterEach
+    fun tearDown() = runTest {
+      scheduleRepository.deleteAll()
+    }
+
+    @Nested
+    inner class HappyPath {
+      val mapping = CourtScheduleMappingDto(
+        "A1234BC",
+        12345L,
+        23456L,
+        UUID.randomUUID(),
+        CourtMappingType.NOMIS_CREATED,
+      )
+
+      @Test
+      fun `should create mapping`() = runTest {
+        webTestClient.upsertCourtScheduleMappingByDpsId(mapping)
+          .expectStatus().isOk
+          .expectBody<CourtScheduleMappingUpsertByDpsIdResponse>()
+          .returnResult().responseBody!!
+          .apply {
+            // We didn't replace the event ID so returns null
+            assertThat(replacedNomisEventId).isNull()
+          }
+
+        with(scheduleRepository.findByNomisEventId(mapping.nomisEventId)!!) {
+          assertThat(offenderNo).isEqualTo("A1234BC")
+          assertThat(bookingId).isEqualTo(12345L)
+          assertThat(dpsCourtAppearanceId).isEqualTo(mapping.dpsCourtAppearanceId)
+          assertThat(mappingType).isEqualTo(CourtMappingType.NOMIS_CREATED)
+        }
+      }
+    }
+
+    @Nested
+    inner class Upsert {
+      val mapping = CourtScheduleMappingDto(
+        "A1234BC",
+        12345L,
+        23456L,
+        UUID.randomUUID(),
+        CourtMappingType.NOMIS_CREATED,
+      )
+      val duplicateMappingDps = CourtScheduleMappingDto(
+        "B2345CD",
+        56789L,
+        34567L,
+        mapping.dpsCourtAppearanceId,
+        CourtMappingType.MIGRATED,
+      )
+      val duplicateMappingNomis = CourtScheduleMappingDto(
+        "C3456DE",
+        9101112L,
+        mapping.nomisEventId,
+        UUID.randomUUID(),
+        CourtMappingType.MIGRATED,
+      )
+
+      @Test
+      fun `should replace duplicate DPS ID mapping and return old nomis ID`() = runTest {
+        webTestClient.upsertCourtScheduleMappingByDpsId(mapping)
+          .expectStatus().isOk
+
+        webTestClient.upsertCourtScheduleMappingByDpsId(duplicateMappingDps)
+          .expectStatus().isOk
+          .expectBody<CourtScheduleMappingUpsertByDpsIdResponse>()
+          .returnResult().responseBody!!
+          .apply {
+            assertThat(replacedNomisEventId).isEqualTo(mapping.nomisEventId)
+          }
+      }
+
+      @Test
+      fun `should reject duplicate NOMIS ID mapping`() = runTest {
+        webTestClient.upsertCourtScheduleMappingByDpsId(mapping)
+          .expectStatus().isOk
+
+        webTestClient.upsertCourtScheduleMappingByDpsId(duplicateMappingNomis)
+          .expectStatus().isDuplicateMapping
+          .expectBody(object : ParameterizedTypeReference<TestDuplicateErrorResponse>() {})
+          .returnResult().responseBody!!
+          .apply {
+            assertThat(moreInfo.existing)
+              .containsEntry("prisonerNumber", mapping.prisonerNumber)
+              .containsEntry("bookingId", mapping.bookingId.toInt())
+              .containsEntry("dpsCourtAppearanceId", mapping.dpsCourtAppearanceId.toString())
+              .containsEntry("nomisEventId", mapping.nomisEventId.toInt())
+              .containsEntry("mappingType", mapping.mappingType.toString())
+            assertThat(moreInfo.duplicate)
+              .containsEntry("prisonerNumber", duplicateMappingNomis.prisonerNumber)
+              .containsEntry("bookingId", duplicateMappingNomis.bookingId.toInt())
+              .containsEntry("dpsCourtAppearanceId", duplicateMappingNomis.dpsCourtAppearanceId.toString())
+              .containsEntry("nomisEventId", duplicateMappingNomis.nomisEventId.toInt())
+              .containsEntry("mappingType", duplicateMappingNomis.mappingType.toString())
+          }
+      }
+    }
+
+    @Nested
+    inner class Security {
+      val mapping = CourtScheduleMappingDto(
+        "A1234BC",
+        12345L,
+        23456L,
+        UUID.randomUUID(),
+        mappingType = CourtMappingType.NOMIS_CREATED,
+      )
+
+      @Test
+      fun `access not authorised when no authority`() {
+        webTestClient.put()
+          .uri("/mapping/court-scheduler/schedule/dps-id")
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(mapping))
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.put()
+          .uri("/mapping/court-scheduler/schedule/dps-id")
+          .headers(setAuthorisation(roles = listOf()))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(mapping))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.put()
+          .uri("/mapping/court-scheduler/schedule/dps-id")
+          .headers(setAuthorisation(roles = listOf("BANANAS")))
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(BodyInserters.fromValue(mapping))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    private fun WebTestClient.upsertCourtScheduleMappingByDpsId(mapping: CourtScheduleMappingDto) = put()
+      .uri("/mapping/court-scheduler/schedule/dps-id")
       .headers(setAuthorisation(roles = listOf("NOMIS_MAPPING_API__SYNCHRONISATION__RW")))
       .contentType(MediaType.APPLICATION_JSON)
       .body(BodyInserters.fromValue(mapping))
@@ -786,4 +933,11 @@ class CourtScheduleResourceIntTest(
     private fun WebTestClient.moveBookingIdsOk(bookingId: Long = 1L, from: String = "A1234AB", to: String = "A9876BA") = moveBookingIds(bookingId, from, to)
       .expectStatus().isOk
   }
+
+  private fun WebTestClient.createCourtScheduleMapping(mapping: CourtScheduleMappingDto) = post()
+    .uri("/mapping/court-scheduler/schedule")
+    .headers(setAuthorisation(roles = listOf("NOMIS_MAPPING_API__SYNCHRONISATION__RW")))
+    .contentType(MediaType.APPLICATION_JSON)
+    .body(BodyInserters.fromValue(mapping))
+    .exchange()
 }


### PR DESCRIPTION
Because of the way RaS sometimes changes their court appearance UUID, we might need to do this workaround in the Court Scheduler mappings. So we created this special endpoint that caters for an existing DPS court scheduler UUID and replaces the NOMIS event ID in that case. For the full scenario please see the JIRA ticket.